### PR TITLE
Stage inference files from PNFS

### DIFF
--- a/.tar.sh
+++ b/.tar.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
-make_tar_uboone.sh strangeness.tar
+set -e
+
+# Default installation directory is $MRB_INSTALL. Allow override via -d.
+dir="${MRB_INSTALL}"
+while getopts "d:" opt; do
+  case "$opt" in
+    d)
+      dir="$OPTARG"
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "$dir" ]; then
+  echo "Installation directory not specified. Set MRB_INSTALL or use -d." >&2
+  exit 1
+fi
+
+mkdir -p "$dir"
+
+cp run_strangeness_inference.sh run_inference.py binary_classifier_resnet34.pth "$dir"
+
+ls "$dir"
+
+make_tar_uboone.sh -d "$dir" strangeness.tar
 cp -f strangeness.tar /pnfs/uboone/resilient/users/nlane/tarballs/strangeness.tar
 rm strangeness.tar
+

--- a/numi_fhc_workflow.xml
+++ b/numi_fhc_workflow.xml
@@ -7,7 +7,7 @@
     <!ENTITY fcl_selection_mc "run_neutrinoselection_mc.fcl">
     <!ENTITY fcl_selection_data "run_neutrinoselection_data.fcl">
 
-    <!ENTITY jobsub_config "--expected-lifetime=24h -f /pnfs/uboone/resilient/users/nlane/misc/badchannels.txt">
+    <!ENTITY jobsub_config "--expected-lifetime=24h -f /pnfs/uboone/resilient/users/nlane/misc/run_strangeness_inference.sh -f /pnfs/uboone/resilient/users/nlane/misc/run_inference.py -f /pnfs/uboone/resilient/users/nlane/misc/binary_classifier_resnet34.pth -f /pnfs/uboone/resilient/users/nlane/misc/badchannels.txt">
 
     <!ENTITY input_def_ext_numi_run1 "nl_prod_mcc9_v08_00_00_45_extnumi_reco2_run1_all_reco2_3000">
     

--- a/stage_to_pnfs.sh
+++ b/stage_to_pnfs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Copy required inference files to a PNFS directory so that jobsub can stage them
+# to worker nodes with -f options. The destination directory can be provided as
+# an argument; otherwise the default resilient path is used.
+
+DEST=${1:-/pnfs/uboone/resilient/users/nlane/misc}
+
+mkdir -p "$DEST"
+
+FILES=(run_strangeness_inference.sh run_inference.py binary_classifier_resnet34.pth badchannels.txt)
+for f in "${FILES[@]}"; do
+  cp "$f" "$DEST/"
+ done
+
+ls "$DEST"


### PR DESCRIPTION
## Summary
- include PNFS-staged inference scripts and model via job submission options
- add helper script to copy inference files into the PNFS directory

## Testing
- `bash -n stage_to_pnfs.sh`
- `xmllint --noout numi_fhc_workflow.xml` *(fails: command not found)*
- `./stage_to_pnfs.sh /tmp/pnfs_test`


------
https://chatgpt.com/codex/tasks/task_e_68ace045d27c832e854767b1d597934d