### PR TITLE
Fix apptainer flag typo

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -565,7 +565,7 @@ namespace analysis {
             bind_paths = "/cvmfs," + bind_paths;
         }
 
-        std::string command = "apptainer exec --cleanev --bind " + bind_paths + " " +
+        std::string command = "apptainer exec --cleanenv --bind " + bind_paths + " " +
             container + " " +
             "/bin/bash ./" + wrapper_script + " " +
             temp_in + " " +


### PR DESCRIPTION
## Summary
- correct apptainer exec flag from `--cleanev` to `--cleanenv`

## Testing
- `cmake ..` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b1fb4bede4832e87ae8637279133d8