### PR TITLE
Add h5py dependency checks for inference scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 ## Building the Project
 
 Before building and running the inference utilities, ensure that required Python
-packages such as `h5py` are available in the runtime environment.
+packages such as `h5py` are available in the runtime environment. The
+`run_strangeness_inference.sh` wrapper attempts to source a Python setup script
+from CVMFS when available so that these dependencies are accessible at runtime.
 
 1. **Set up the environment:**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Building the Project
 
+Before building and running the inference utilities, ensure that required Python
+packages such as `h5py` are available in the runtime environment.
+
 1. **Set up the environment:**
 
    ```bash

--- a/run_inference.py
+++ b/run_inference.py
@@ -1,6 +1,10 @@
 import sys
 import os
-import h5py
+try:
+  import h5py
+except ModuleNotFoundError:
+  print("Error: h5py is required but not installed. Please install h5py to run this script.")
+  sys.exit(1)
 import torch
 import MinkowskiEngine as ME
 import numpy as np

--- a/run_strangeness_inference.sh
+++ b/run_strangeness_inference.sh
@@ -8,6 +8,23 @@ TREE_NAME="$4"
 BRANCH_NAME="$5"
 unset PYTHONHOME
 unset PYTHONPATH
+# Attempt to source a Python environment from CVMFS so that required
+# libraries like h5py are available.
+PY_SETUP=""
+for pyroot in \
+  /cvmfs/uboone.opensciencegrid.org/products/python \
+  /cvmfs/larsoft.opensciencegrid.org/products/python; do
+  if [ -d "$pyroot" ]; then
+    PY_SETUP=$(find "$pyroot" -maxdepth 2 -name setup.sh 2>/dev/null | head -n 1)
+    if [ -n "$PY_SETUP" ]; then
+      source "$PY_SETUP"
+      break
+    fi
+  fi
+done
+if [ -z "$PY_SETUP" ]; then
+  echo "Warning: No CVMFS Python setup script found; using system Python."
+fi
 if ! python3 -c "import h5py" >/dev/null 2>&1; then
   echo "Error: Python module 'h5py' is required but not installed."
   exit 1

--- a/run_strangeness_inference.sh
+++ b/run_strangeness_inference.sh
@@ -8,6 +8,10 @@ TREE_NAME="$4"
 BRANCH_NAME="$5"
 unset PYTHONHOME
 unset PYTHONPATH
+if ! python3 -c "import h5py" >/dev/null 2>&1; then
+  echo "Error: Python module 'h5py' is required but not installed."
+  exit 1
+fi
 if [ -z "$INPUT_FILE" ] || [ ! -f "$INPUT_FILE" ]; then
   echo "Error: Input file '$INPUT_FILE' is missing or not provided."
   exit 1

--- a/test_container_env.sh
+++ b/test_container_env.sh
@@ -28,6 +28,9 @@ python3 -c "import torch; print('PyTorch version:', torch.__version__)"
 echo
 echo "--- 4. Checking for uproot ---"
 python3 -c "import uproot; print('uproot version:', uproot.__version__)"
+echo
+echo "--- 5. Checking for h5py ---"
+python3 -c "import h5py; print('h5py version:', h5py.__version__)" || echo "h5py not available"
 echo "--- Test script finished ---"
 exit 0
 

--- a/test_container_env.sh
+++ b/test_container_env.sh
@@ -2,6 +2,25 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/env/setenv.sh"
 source "${SCRIPT_DIR}/env/configure.sh"
+unset PYTHONHOME
+unset PYTHONPATH
+# Try to source a Python setup script from CVMFS to match the runtime
+# environment used by the inference wrapper.
+PY_SETUP=""
+for pyroot in \
+  /cvmfs/uboone.opensciencegrid.org/products/python \
+  /cvmfs/larsoft.opensciencegrid.org/products/python; do
+  if [ -d "$pyroot" ]; then
+    PY_SETUP=$(find "$pyroot" -maxdepth 2 -name setup.sh 2>/dev/null | head -n 1)
+    if [ -n "$PY_SETUP" ]; then
+      source "$PY_SETUP"
+      break
+    fi
+  fi
+done
+if [ -z "$PY_SETUP" ]; then
+  echo "Warning: No CVMFS Python setup script found; using system Python."
+fi
 echo "--- Starting container test script (test_container_env.sh) ---"
 while [[ $# -gt 0 ]]; do
   key="$1"


### PR DESCRIPTION
## Summary
- add explicit h5py import check to `run_inference.py`
- validate h5py presence in `run_strangeness_inference.sh`
- extend environment test script to report h5py availability
- document h5py requirement in README

## Testing
- `bash test_container_env.sh` *(fails: h5py not available)*


------
https://chatgpt.com/codex/tasks/task_e_68b1ff72441c832ea587c765799bedca