### PR TITLE
Improve inference error reporting

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -3,10 +3,14 @@ import os
 try:
   import h5py
 except ModuleNotFoundError:
-  print("Error: h5py is required but not installed. Please install h5py to run this script.")
+  print("Error: h5py is required but not installed. Please install h5py to run this script.", file=sys.stderr)
+  sys.exit(1)
+try:
+  import MinkowskiEngine as ME
+except ModuleNotFoundError:
+  print("Error: MinkowskiEngine is required but not installed. Please install MinkowskiEngine to run this script.", file=sys.stderr)
   sys.exit(1)
 import torch
-import MinkowskiEngine as ME
 import numpy as np
 import argparse
 import time


### PR DESCRIPTION
## Summary
- Emit dependency errors to stderr in `run_inference.py`
- Add explicit check for missing MinkowskiEngine

## Testing
- `python3 -m py_compile run_inference.py`
- `python3 run_inference.py --help 1>stdout.txt 2>stderr.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b209a5bfc8832e9a1fd11886b84b47