### PR TITLE
Gracefully handle missing bashrc during UPS setup

### DIFF
--- a/run_strangeness_inference.sh
+++ b/run_strangeness_inference.sh
@@ -2,9 +2,23 @@
 set -e
 
 # Ensure UPS products such as HDF5 are available
+if [ ! -f /etc/bashrc ]; then
+  echo '# minimal bashrc' > /tmp/bashrc
+  export BASH_ENV=/tmp/bashrc
+fi
+set +e
 source /cvmfs/uboone.opensciencegrid.org/products/setup_uboone.sh
-setup hdf5 v1_12_2a -q e20:prof
-ups active hdf5
+setup_rc=$?
+set -e
+if [ "$setup_rc" -eq 0 ]; then
+  setup hdf5 v1_12_2a -q e20:prof
+  ups active hdf5
+elif [ ! -f /etc/bashrc ]; then
+  echo "Warning: UPS setup failed and /etc/bashrc is missing; proceeding without UPS environment." >&2
+else
+  echo "Error: failed to source UPS setup script" >&2
+  exit 1
+fi
 
 # Locate and source the ROOT setup script. Prefer a standard installation
 # discovered via `root-config` but fall back to the historical location


### PR DESCRIPTION
## Summary
- Allow `run_strangeness_inference.sh` to continue when UPS setup fails due to missing `/etc/bashrc`
- Create temporary `/tmp/bashrc` and set `BASH_ENV` before sourcing UPS setup
- Only run UPS `setup` commands when the setup script succeeds and warn otherwise

## Testing
- `bash -n run_strangeness_inference.sh`
- `bash test_container_env.sh` *(fails: /usr/local/root/bin/thisroot.sh not found, modules torch/uproot/h5py missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e056c790832eaff7801e4d5860f1