### PR TITLE
Switch inference I/O from HDF5 to NPY

### DIFF
--- a/AnalysisTools/CMakeLists.txt
+++ b/AnalysisTools/CMakeLists.txt
@@ -1,7 +1,5 @@
 cet_enable_asserts()
 
-find_package(HDF5 REQUIRED COMPONENTS C CXX)
-include_directories(${HDF5_INCLUDE_DIRS})
 
 art_make( TOOL_LIBRARIES lardataobj_RecoBase
                          lardataobj_Simulation
@@ -52,7 +50,6 @@ art_make( TOOL_LIBRARIES lardataobj_RecoBase
                          ubreco_BlipRecoAlg
                            ${LIBTORCH_LIBRARIES}
                            ${ROOT_GEOM}
-                           ${HDF5_LIBRARIES}
                            stdc++fs
         )
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 ## Building the Project
 
 Before building and running the inference utilities, ensure that the runtime
-environment provides the Python packages `h5py` and `MinkowskiEngine`. The
-`run_strangeness_inference.sh` wrapper attempts to source a Python setup script
-from CVMFS and will try to install `h5py` if it is missing, but
-`MinkowskiEngine` must already be available.
+environment provides the Python packages `numpy` and `MinkowskiEngine`. The
+`run_strangeness_inference.sh` wrapper simply forwards arguments to the Python
+script, so `MinkowskiEngine` must already be available in the environment.
 
 To execute within a container, bind the necessary CVMFS directories so these
 dependencies can be located. For example:
@@ -17,7 +16,7 @@ apptainer exec \
   --bind /exp/uboone:/exp/uboone \
   --bind /pnfs/uboone:/pnfs/uboone \
   /cvmfs/uboone.opensciencegrid.org/containers/uboone-devel-sl7 \
-  ./run_strangeness_inference.sh <input.root> <output.root> <weights.pth> <tree> <branch>
+  ./run_strangeness_inference.sh --npy <images.npy> --output <scores.txt> --weights <weights.pth>
 ```
 
 ### Variable Reference
@@ -30,8 +29,6 @@ with a value appropriate for your environment.
 | `<input.root>` | Input ROOT file containing events for inference. | `events.root` |
 | `<output.root>` | Output ROOT file written by the inference script. | `results.root` |
 | `<weights.pth>` | Neural-network weight file. | `model_weights.pth` |
-| `<tree>` | Name of the TTree within the input file. | `ImageTree` |
-| `<branch>` | Branch within the TTree to process. | `image_branch` |
 | `<sam_definition>` | SAM dataset definition name. | `prod_strange_resample_fhc_run2` |
 | `<num_files>` | Number of files to select from a SAM definition. | `250` |
 | `<file>` | Specific file returned from SAM queries. | `file1.root` |

--- a/run_strangeness_inference.sh
+++ b/run_strangeness_inference.sh
@@ -1,77 +1,9 @@
-#!/bin/bash
-set -ex
+#!/usr/bin/env bash
+set -euo pipefail
+unset PYTHONHOME PYTHONPATH
+export PYTHONNOUSERSITE=1
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
 
-echo "--- Checking for CVMFS ---"
-if [ ! -d /cvmfs ]; then
-  echo "Error: /cvmfs is not accessible inside the container." >&2
-  echo "You may need to explicitly bind it, e.g., 'apptainer exec --bind /cvmfs ...'." >&2
-  exit 1
-fi
-echo "--- CVMFS found ---"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "${script_dir}/run_inference.py" "$@"
 
-echo "--- Sourcing official uboone setup script ---"
-# Temporarily disable exit-on-error to handle non-fatal warnings
-set +e
-source /cvmfs/uboone.opensciencegrid.org/products/setup_uboone.sh
-source_rc=$?
-set -e
-
-# We will ignore the exit code for now, as the interactive test proved it works
-# despite the script's internal errors.
-echo "--- uboone setup script sourced ---"
-
-echo "--- Setting up hdf5 (suppressing harmless warnings) ---"
-setup hdf5 v1_12_2a -q e20:prof 2>/dev/null
-echo "--- hdf5 setup complete ---"
-
-echo "--- Verifying hdf5 setup ---"
-ups active hdf5
-
-echo "--- Locating and sourcing ROOT ---"
-if command -v root-config >/dev/null 2>&1; then
-  source "$(root-config --prefix)/bin/thisroot.sh"
-else
-  source "/usr/local/root/bin/thisroot.sh"
-fi
-echo "--- ROOT setup complete ---"
-
-INPUT_FILE="$1"
-OUTPUT_FILE="$2"
-WEIGHTS_FILE="$3"
-TREE_NAME="$4"
-BRANCH_NAME="$5"
-
-echo "--- Input arguments received ---"
-echo "Input file: ${INPUT_FILE}"
-echo "Output file: ${OUTPUT_FILE}"
-echo "Weights file: ${WEIGHTS_FILE}"
-echo "Tree name: ${TREE_NAME}"
-echo "Branch name: ${BRANCH_NAME}"
-
-unset PYTHONHOME
-unset PYTHONPATH
-
-echo "--- Setting up Python from CVMFS ---"
-PY_SETUP=$(find /cvmfs/uboone.opensciencegrid.org/products/python /cvmfs/larsoft.opensciencegrid.org/products/python -name "setup.sh" 2>/dev/null | head -n 1)
-if [ -n "$PY_SETUP" ]; then
-    source "$PY_SETUP"
-    echo "--- Sourced Python from $PY_SETUP ---"
-else
-    echo "--- Could not find Python setup script in CVMFS ---"
-fi
-
-echo "--- Starting Python inference script ---"
-python3 run_inference.py \
-  --input "$INPUT_FILE" \
-  --output "$OUTPUT_FILE" \
-  --weights "$WEIGHTS_FILE" \
-  --tree "$TREE_NAME" \
-  --branch "$BRANCH_NAME"
-echo "--- Python script finished ---"
-
-echo "--- Verifying output file creation ---"
-if [ ! -f "$OUTPUT_FILE" ]; then
-  echo "Error: Python script did not create the expected output file: ${OUTPUT_FILE}" >&2
-  exit 1
-fi
-echo "--- Script completed successfully, output file found. ---"

--- a/setup.sh
+++ b/setup.sh
@@ -2,16 +2,3 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/env/setenv.sh"
 source "${SCRIPT_DIR}/env/configure.sh"
-
-# Configure HDF5 include and library paths
-if command -v h5c++ >/dev/null 2>&1; then
-  HDF5_INC=$(h5c++ -showconfig | awk -F: '/Include directories/ {print $2}' | awk '{print $1}')
-  HDF5_LIB=$(h5c++ -showconfig | awk -F: '/Library directories/ {print $2}' | awk '{print $1}')
-  export CPLUS_INCLUDE_PATH="${HDF5_INC}:${CPLUS_INCLUDE_PATH}"
-  export LIBRARY_PATH="${HDF5_LIB}:${LIBRARY_PATH}"
-  export LD_LIBRARY_PATH="${HDF5_LIB}:${LD_LIBRARY_PATH}"
-elif [ -d /usr/include/hdf5/serial ] && [ -d /usr/lib/x86_64-linux-gnu/hdf5/serial ]; then
-  export CPLUS_INCLUDE_PATH="/usr/include/hdf5/serial:${CPLUS_INCLUDE_PATH}"
-  export LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LIBRARY_PATH}"
-  export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH}"
-fi


### PR DESCRIPTION
## Summary
- Replace HDF5 input pipeline with NPY support and remove h5py usage
- Write detector images as .npy in C++ and call Python with `--npy`
- Simplify wrapper script and drop HDF5 build dependencies
- Locate `run_inference.py` relative to wrapper for reliable execution

## Testing
- `python3 -m pip install numpy` *(fails: This environment is externally managed)*
- `python3 run_inference.py --npy image_w.npy --output out.txt --weights weights.pth` *(fails: MinkowskiEngine is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b57eb96790832ea125b0b54ec00df3