### PR TITLE
Install models, weights and scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,3 +74,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 install_headers()
 install_fhicl()
 install_source()
+
+# Install auxiliary data files
+install(FILES badchannels.txt DESTINATION ${product}/data)
+
+# Install model architectures and weight files
+install(DIRECTORY models weights DESTINATION ${product}/data
+        FILES_MATCHING PATTERN "*")
+
+# Install Python and Bash scripts for inference pipeline
+file(GLOB STRANGENESS_SCRIPTS "*.py" "*.sh")
+install(FILES ${STRANGENESS_SCRIPTS} DESTINATION ${product}/scripts)


### PR DESCRIPTION
## Summary
- install badchannels.txt and model/weight directories into product data
- deploy inference Python/Bash scripts with the package

## Testing
- `python -m py_compile *.py`
- `bash -n *.sh`
- `python run_inference.py --help` *(fails: MinkowskiEngine is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cb58b21c832ebc08b309444c38d7