### PR TITLE
Resolve resources via framework search path

### DIFF
--- a/run_strangeness_inference.sh
+++ b/run_strangeness_inference.sh
@@ -4,6 +4,34 @@ unset PYTHONHOME PYTHONPATH
 export PYTHONNOUSERSITE=1
 export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-python3 "${script_dir}/run_inference.py" "$@"
+echo "CWD: $(pwd)"
+ls -al
+
+fw_script=""
+if [[ -n "${FW_SEARCH_PATH:-}" ]]; then
+  IFS=':' read -ra dirs <<< "$FW_SEARCH_PATH"
+  for d in "${dirs[@]}"; do
+    if [[ -f "$d/run_inference.py" ]]; then
+      fw_script="$d/run_inference.py"
+      break
+    fi
+  done
+fi
+if [[ -z "$fw_script" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  candidate="${script_dir}/run_inference.py"
+  if [[ -f "$candidate" ]]; then
+    fw_script="$candidate"
+  fi
+fi
+if [[ -z "$fw_script" || ! -f "$fw_script" ]]; then
+  echo "run_inference.py not found" >&2
+  echo "CWD: $(pwd)" >&2
+  ls -al >&2
+  exit 1
+else
+  echo "Using run_inference.py at $fw_script"
+fi
+
+python3 "$fw_script" "$@"
 


### PR DESCRIPTION
## Summary
- log resolved bad-channel file and current working directory during configuration
- emit working directory listings in inference scripts and report full paths to resources
- halt with directory listing when `run_inference.py` or model weights are missing

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b757f2a598832eb97c4f697926f76c