### PR TITLE
Fix include paths for ImageAnalysis_tool

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -58,8 +58,8 @@
 #include "AnalysisToolBase.h"
 #include "../CommonDefs/Pandora.h"
 #include "../CommonDefs/Types.h"
-#include "../Image.h"
-#include "../ImageAlgorithm.h"
+#include "../CommonDefs/Image.h"
+#include "../CommonDefs/ImageAlgorithm.h"
 
 namespace fs = std::experimental::filesystem;
 


### PR DESCRIPTION
## Summary
- update ImageAnalysis_tool to include Image.h and ImageAlgorithm.h from CommonDefs

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b828013a54832eb8ec951cce10c9e1