### PR TITLE
Add job CMakeLists for FHiCL installation

### DIFF
--- a/job/CMakeLists.txt
+++ b/job/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()


### PR DESCRIPTION
## Summary
- Add job CMakeLists.txt to install FHiCL files
- Remove references to nonexistent subdirectories

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b827cec188832e94d96c3c3ca5f231