### PR TITLE
Add unified tarball packaging script and update workflow

### DIFF
--- a/scripts/.tar.sh
+++ b/scripts/.tar.sh
@@ -1,5 +1,53 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# .tar.sh — build and publish tarballs for local larsoft and analysis assets
+#
+# This script creates two tarballs and places them in a common tarball
+# directory:
+#   1. LArSoft build (strangeness.tar)
+#   2. Analysis assets (strangeness_assets.tar.gz)
+#
+# Environment variables used for customisation:
+#   TAR_DIR      - destination directory for the tarballs
+#   ASSETS_ROOT  - location of the assets tree
+#
+# After running, the following variables are exported for convenience:
+#   STRANGENESS_TAR         - full path to the LArSoft tarball
+#   STRANGENESS_ASSETS_TAR  - full path to the assets tarball
 
-.tar_uboone.sh strangeness.tar
-cp -f strangeness.tar /pnfs/uboone/scratch/users/nlane/tarballs/strangeness.tar
-rm strangeness.tar
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Destination for tarballs; default to user's scratch area
+TAR_DIR="${TAR_DIR:-/pnfs/uboone/scratch/users/${USER}/tarballs}"
+# Location of the assets to package
+ASSETS_ROOT="${ASSETS_ROOT:-${REPO_ROOT}/assets}"
+
+LARSOFT_TAR="${TAR_DIR}/strangeness.tar"
+ASSETS_TAR="${TAR_DIR}/strangeness_assets.tar.gz"
+
+mkdir -p "${TAR_DIR}"
+
+pushd "${REPO_ROOT}" >/dev/null
+
+# Build the larsoft tarball
+"${SCRIPT_DIR}/.tar_uboone.sh" strangeness.tar
+mv -f strangeness.tar "${LARSOFT_TAR}"
+
+# Build the assets tarball
+"${SCRIPT_DIR}/.pack_assets.sh" -r "${ASSETS_ROOT}" -o strangeness_assets.tar.gz
+mv -f strangeness_assets.tar.gz "${ASSETS_TAR}"
+
+popd >/dev/null
+
+export STRANGENESS_TAR="${LARSOFT_TAR}"
+export STRANGENESS_ASSETS_TAR="${ASSETS_TAR}"
+
+echo "LArSoft tarball:  ${STRANGENESS_TAR}"
+echo "Assets tarball:  ${STRANGENESS_ASSETS_TAR}"
+echo "Environment variables set:"
+echo "  export STRANGENESS_TAR=${STRANGENESS_TAR}"
+echo "  export STRANGENESS_ASSETS_TAR=${STRANGENESS_ASSETS_TAR}"
+

--- a/xml/numi_fhc_workflow.xml
+++ b/xml/numi_fhc_workflow.xml
@@ -7,9 +7,11 @@
     <!ENTITY fcl_selection_mc "run_neutrinoselection_mc.fcl">
     <!ENTITY fcl_selection_data "run_neutrinoselection_data.fcl">
 
+    <!ENTITY tar_dir "/pnfs/uboone/scratch/users/nlane/tarballs">
+    <!ENTITY larsoft_tar "&tar_dir;/strangeness.tar">
+    <!ENTITY assets_tar "&tar_dir;/strangeness_assets.tar.gz">
     <!ENTITY jobsub_config "
-        -e STRANGENESS_DIR=$CONDOR_DIR_INPUT 
-        -e FW_SEARCH_PATH=$CONDOR_DIR_INPUT/ubana/data:${FW_SEARCH_PATH}"
+        --tar_file_name=file://&assets_tar;"
     >
 
     <!ENTITY input_def_ext_numi_run1 "nl_prod_mcc9_v08_00_00_45_extnumi_reco2_run1_all_reco2_3000">
@@ -47,7 +49,7 @@
     <larsoft>
         <tag>&release;</tag>
         <qual>e17:prof</qual>
-        <local>/pnfs/uboone/scratch/users/nlane/tarballs/strangeness.tar</local>
+        <local>&larsoft_tar;</local>
     </larsoft>
     <check>1</check>
     <copy>0</copy>


### PR DESCRIPTION
## Summary
- add script to package both local LArSoft build and analysis assets
- reference LArSoft and asset tarballs consistently in workflow XML
- drop unused STRANGENESS_DIR and FW_SEARCH_PATH exports from job configuration

## Testing
- `bash -n scripts/.tar.sh`
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('xml/numi_fhc_workflow.xml')
print('XML parsed successfully')
PY`
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y shellcheck libxml2-utils` *(fails: Unable to locate packages)*
- `shellcheck scripts/.tar.sh` *(command not found)*
- `xmllint --noout xml/numi_fhc_workflow.xml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b827afe610832eb57f71bbb3fba810