### PR TITLE
Improve process script robustness

### DIFF
--- a/scripts/.process.sh
+++ b/scripts/.process.sh
@@ -1,6 +1,26 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -euo pipefail
+IFS=$'\n\t'
+
+cleanup_temp_dir() {
+    if [[ -n "${TEMP_DIR:-}" && -d "${TEMP_DIR}" ]]; then
+        echo "Cleaning up temporary files in ${TEMP_DIR}..."
+        rm -rf "${TEMP_DIR}" || {
+            echo "Warning: Failed to remove temporary directory '${TEMP_DIR}'. Manual cleanup might be needed."
+        }
+        echo "Temporary files cleaned."
+    fi
+}
+
+trap cleanup_temp_dir EXIT
+
+check_command() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "Error: required command '$1' not found. Exiting..."
+        exit 1
+    }
+}
 
 fetch_files_from_sam() {
     local files_list=$(samweb list-files defname:"${SAM_DEF}" | head -n "${NUM_FILES}")
@@ -61,14 +81,6 @@ combine_output_files() {
     echo "Successfully combined ROOT files into: ${COMBINED_OUTPUT}"
 }
 
-cleanup_temp_dir() {
-    echo "Cleaning up temporary files in ${TEMP_DIR}..."
-    rm -rf "${TEMP_DIR}" || {
-        echo "Warning: Failed to remove temporary directory '${TEMP_DIR}'. Manual cleanup might be needed."
-    }
-    echo "Temporary files cleaned."
-}
-
 FHICL_FILE="$1"
 NUM_FILES="$2"
 SAM_DEF="New_NuMI_Flux_Run_1_FHC_Pandora_Reco2_reco2_reco2"
@@ -76,6 +88,10 @@ OUTPUT_BASE_DIR="/exp/uboone/data/users/$USER/analysis"
 FHICL_BASE=$(basename "${FHICL_FILE}" .fcl | sed 's/^run_//')
 COMBINED_OUTPUT="${OUTPUT_BASE_DIR}/${SAM_DEF}_${FHICL_BASE}_${NUM_FILES}_new_analysis.root"
 TEMP_DIR="${OUTPUT_BASE_DIR}/temp_root_files"
+
+check_command samweb
+check_command lar
+check_command hadd
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: $(basename "$0") <fhicl_file> <num_files>"
@@ -90,6 +106,5 @@ process_files_with_lar "${FETCHED_FILES}"
 
 combine_output_files
 
-cleanup_temp_dir
-
 echo "Process complete!"
+


### PR DESCRIPTION
## Summary
- harden process script with strict error handling and controlled word splitting
- ensure temporary files are always cleaned via EXIT trap
- verify samweb, lar, and hadd are available before running

## Testing
- `command -v shellcheck >/dev/null 2>&1 && shellcheck scripts/.process.sh || echo 'shellcheck not available'`
- `apt-get update`
- `bash -n scripts/.process.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b82a111e5c832ebc2cd1e5466c255c