### PR TITLE
feat: make summary script accept custom definitions

### DIFF
--- a/scripts/.summary.sh
+++ b/scripts/.summary.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-input_definitions=(
+# Default definitions used when no input is supplied
+default_definitions=(
     "New_NuMI_Flux_Run_1_FHC_Pandora_Reco2_reco2_reco2"
     "prod_strange_resample_fhc_run2_fhc_reco2_reco2"
     "detvar_prod_strange_resample_fhc_run1_respin_cv_reco2_reco2"
@@ -23,6 +24,27 @@ input_definitions=(
     "prodgenie_numi_nu_overlay_v08_00_00_53_WireModThetaXZ_300k_reco2_run1_reco2"
     "prodgenie_numi_nu_overlay_detvar_WireModThetaYZ_withSplines_run1_reco2_run1_reco2"
 )
+
+usage() {
+    echo "Usage: $(basename "$0") [definition_file | def1 def2 ...]"
+    echo "Provide SAM dataset definitions via a file or command-line list."
+}
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+# Determine input definitions from arguments or fall back to defaults
+if [[ $# -gt 0 ]]; then
+    if [[ -f "$1" ]]; then
+        mapfile -t input_definitions < "$1"
+    else
+        input_definitions=("$@")
+    fi
+else
+    input_definitions=("${default_definitions[@]}")
+fi
 
 echo "--- Samweb List Summary Definitions ---"
 echo ""


### PR DESCRIPTION
## Summary
- allow `scripts/.summary.sh` to read dataset definitions from a file or CLI arguments
- retain bundled definitions when none provided
- add `--help` option describing usage

## Testing
- `bash -n scripts/.summary.sh`
- `bash scripts/.summary.sh --help`
- `bash scripts/.summary.sh` *(fails: `samweb` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82a11e048832eb4ff0e4aa7bd5816