### PR TITLE
Parameterize setup script versions and add checks

### DIFF
--- a/scripts/.setup.sh
+++ b/scripts/.setup.sh
@@ -1,4 +1,37 @@
 #!/bin/bash
+set -euo pipefail
+
+# Default software versions. Override via environment variables or
+# command-line arguments (e.g., --uboonecode-version vX_Y_Z).
+UBOONECODE_VERSION="${UBOONECODE_VERSION:-v08_00_00_82}"
+HDF5_VERSION="${HDF5_VERSION:-v1_10_5}"
+LIBTORCH_VERSION="${LIBTORCH_VERSION:-v1_0_1}"
+PYTHON_VERSION="${PYTHON_VERSION:-v2_7_14b}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --uboonecode-version)
+      UBOONECODE_VERSION="${2:?--uboonecode-version requires an argument}"
+      shift 2
+      ;;
+    --hdf5-version)
+      HDF5_VERSION="${2:?--hdf5-version requires an argument}"
+      shift 2
+      ;;
+    --libtorch-version)
+      LIBTORCH_VERSION="${2:?--libtorch-version requires an argument}"
+      shift 2
+      ;;
+    --python-version)
+      PYTHON_VERSION="${2:?--python-version requires an argument}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # Load the UPS setup to make `setup` and `unsetup_all` available.
 if ! command -v setup >/dev/null 2>&1; then
@@ -14,25 +47,34 @@ fi
 unsetup_all || true
 
 source /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh
-setup uboonecode v08_00_00_82 -q e17:prof
-#setup libtorch v1_0_1 -q Linux64bit+3.10-2.17:e17:prof
-setup hdf5 v1_10_5 -q e17
+setup uboonecode "$UBOONECODE_VERSION" -q e17:prof
+#setup libtorch "$LIBTORCH_VERSION" -q Linux64bit+3.10-2.17:e17:prof
+setup hdf5 "$HDF5_VERSION" -q e17
 
 setup sam_web_client
 
 export WRK_DIR=$(pwd)
 source ../../../../localProducts_*/setup
-mrbslp
+if ! mrbslp; then
+  echo "mrbslp failed" >&2
+  exit 1
+fi
 
-htgettoken -a htvaultprod.fnal.gov -i uboone
+if ! htgettoken -a htvaultprod.fnal.gov -i uboone; then
+  echo "htgettoken failed" >&2
+  exit 1
+fi
 
 which jobsub_submit
 
-export TORCH_DIR_BASE=/cvmfs/uboone.opensciencegrid.org/products/libtorch/v1_0_1/Linux64bit+3.10-2.17-e17-prof/lib/python2.7
+export TORCH_DIR_BASE="/cvmfs/uboone.opensciencegrid.org/products/libtorch/${LIBTORCH_VERSION}/Linux64bit+3.10-2.17-e17-prof/lib/python2.7"
 export TORCH_DIR="$TORCH_DIR_BASE/site-packages/torch/share/cmake/Torch"
 export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$TORCH_DIR"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/cvmfs/larsoft.opensciencegrid.org/products/python/v2_7_14b/Linux64bit+3.10-2.17/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/cvmfs/larsoft.opensciencegrid.org/products/python/${PYTHON_VERSION}/Linux64bit+3.10-2.17/lib"
 
-kx509
+if ! kx509; then
+  echo "kx509 failed" >&2
+  exit 1
+fi
 voms-proxy-init -noregen -voms fermilab:/fermilab/uboone/Role=Analysis
 


### PR DESCRIPTION
## Summary
- add strict error handling and configurable version defaults to `.setup.sh`
- allow overriding uboonecode, hdf5, libtorch, and python versions via CLI or environment
- ensure `mrbslp`, `htgettoken`, and `kx509` failures exit with clear messages

## Testing
- `bash -n scripts/.setup.sh`
- `shellcheck scripts/.setup.sh` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82a13cfec832e928c9ed06edd6fc8