### PR TITLE
Remove system call from ImageAnalysis tool

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -277,8 +277,16 @@ static inline bool starts_with(const std::string &s, const char *p) {
         }
         char cwd[PATH_MAX];
         if (getcwd(cwd, sizeof(cwd))) {
-          mf::LogInfo("ImageAnalysis") << "Job CWD: " << cwd;
-          std::system("ls -al");
+          mf::LogInfo log("ImageAnalysis");
+          log << "Job CWD: " << cwd << '\n';
+          try {
+            for (const auto &entry : fs::directory_iterator(cwd)) {
+              log << "  " << entry.path().filename().string() << '\n';
+            }
+          } catch (const fs::filesystem_error &e) {
+            mf::LogWarning("ImageAnalysis")
+                << "Unable to list directory contents: " << e.what();
+          }
         }
       }
       fWeightsBaseDir = p.get<std::string>("WeightsBaseDir", "");


### PR DESCRIPTION
## Summary
- Replace `std::system("ls -al")` with filesystem-based listing using `mf::LogInfo`

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b835abd844832e9e4939c220fbf5e3