### PR TITLE
Use std::string_view starts_with in ImageAnalysis tool

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -57,6 +57,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unistd.h>
 #include <unordered_map>
 #include <utility>
@@ -66,18 +67,16 @@ namespace fs = std::experimental::filesystem;
 
 namespace analysis {
 
-static inline bool starts_with(const std::string &s, const char *p) {
-  return s.rfind(p, 0) == 0;
+static inline bool is_remote_url(const std::string &s) {
+  std::string_view sv{s};
+  return sv.starts_with("http:") || sv.starts_with("https:");
 }
 
-    static inline bool is_remote_url(const std::string& s) {
-        return starts_with(s, "http:
-    }
-
-    static inline bool is_pnfs(const std::string& s) {
-      return starts_with(s, "/pnfs/") || starts_with(s, "/eos/") ||
-             starts_with(s, "/stash/");
-    }
+static inline bool is_pnfs(const std::string &s) {
+  std::string_view sv{s};
+  return sv.starts_with("/pnfs/") || sv.starts_with("/eos/") ||
+         sv.starts_with("/stash/");
+}
 
     static std::optional<std::string>
     find_file_nearby(const fs::path &start, const std::string &filename,


### PR DESCRIPTION
## Summary
- drop custom `starts_with` helper
- use `std::string_view::starts_with` for URL and pnfs path helpers

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command `install_headers`)*

------
https://chatgpt.com/codex/tasks/task_e_68b835c80ab0832ebab445ee2941dc58