### PR TITLE
Refactor neutrino selection configuration to use shared filter

### DIFF
--- a/run_neutrinoselection.fcl
+++ b/run_neutrinoselection.fcl
@@ -33,36 +33,8 @@ source: {
 physics: {
     filters: {
         nuselection: {
-            module_type: "EventSelectionFilter"
-            PFPproducer: @local::standard_producers.PFPproducer
-            CLSproducer: @local::standard_producers.CLSproducer
-            SLCproducer: @local::standard_producers.SLCproducer
-            HITproducer: @local::standard_producers.HITproducer
-            SHRproducer: @local::standard_producers.SHRproducer
-            VTXproducer: @local::standard_producers.VTXproducer
-            TRKproducer: @local::standard_producers.TRKproducer
-            PCAproducer: @local::standard_producers.PCAproducer
-            MCPproducer: @local::standard_producers.MCPproducer
-            WIREproducer: @local::standard_producers.WIREproducer
-            MCTproducer: @local::standard_producers.MCTproducer
-            BackTrackerLabel: @local::standard_producers.BKTproducer
-            DeadChannelTag: "nfbadchannel:badchannels:OverlayDetsim"
-            Verbose: false
+            @local::NeutrinoSelectionFilter
             IsData: @is_data
-            IsFakeData: false
-            Filter: true
-            SelectionTool: @local::NeutrinoSelection
-            AnalysisTools: {
-                truth: @local::TruthAnalysis
-                default: @local::DefaultAnalysis
-                energy: @local::EnergyAnalysis
-                image: @local::ImageAnalysis
-                flash: @local::FlashAnalysis
-                weight: @local::EventWeightAnalysis
-                blips: @local::BlipAnalysis
-                tracks: @local::TrackAnalysis
-                slice: @local::SliceAnalysis
-            }
         }
     }
     path1: [ nuselection ]


### PR DESCRIPTION
## Summary
- use centralized `NeutrinoSelectionFilter` instead of inlined filter configuration
- override only the `IsData` parameter in `run_neutrinoselection.fcl`

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command `install_headers`)*

------
https://chatgpt.com/codex/tasks/task_e_68b838bd9d5c832e90814de5de9546de