### PR TITLE
Ensure Common headers are found without SEARCH_TOP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories( $ENV{PANDORA_INC} )
 include_directories( $ENV{LARPANDORACONTENT_INC} )
-include_directories( $ENV{SEARCH_TOP} )
+if(DEFINED ENV{SEARCH_TOP})
+  include_directories( $ENV{SEARCH_TOP} )
+endif()
+include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
 
 


### PR DESCRIPTION
## Summary
- Ensure build can find project headers even when SEARCH_TOP is unset by adding the repository root to the include search path

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers" due to missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b83bff9260832eb01d1eef283446a4