### PR TITLE
Ensure Common headers found without SEARCH_TOP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories( $ENV{PANDORA_INC} )
 include_directories( $ENV{LARPANDORACONTENT_INC} )
 include_directories( $ENV{SEARCH_TOP} )
+# Add the repository's root directory to the include search path so
+# headers in the "Common" directory (e.g. Common/ProxyTypes.h) are
+# found even when the SEARCH_TOP environment variable is unset.
+include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
 # Ensure C++17 features (e.g. std::filesystem) are available
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
## Summary
- add repository root to CMake include path so Common headers like `ProxyTypes.h` are always found

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b83dfc0ae8832e95702f9b54d565f2