### PR TITLE
Remove SimChannel references and streamline NPY utilities

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -31,7 +31,6 @@
 #include "lardataobj/RecoBase/Slice.h"
 #include "lardataobj/RecoBase/Vertex.h"
 #include "lardataobj/RecoBase/Wire.h"
-#include "lardataobj/Simulation/SimChannel.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"

--- a/Common/HitProximityClustering.h
+++ b/Common/HitProximityClustering.h
@@ -289,5 +289,3 @@ bool cluster(const std::vector<art::Ptr<recob::Hit>> &hit_ptr_v,
 } // namespace common
 
 #endif // HITPROXIMITYCLUSTERING_H
-
-/

--- a/Common/ImageTypes.h
+++ b/Common/ImageTypes.h
@@ -11,7 +11,6 @@
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Wire.h"
-#include "lardataobj/Simulation/SimChannel.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcore/Geometry/Geometry.h"
 #include "lardata/Utilities/GeometryUtilities.h"

--- a/Common/NpyUtils.h
+++ b/Common/NpyUtils.h
@@ -6,8 +6,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include "art/Utilities/Exception.h"
+#include <stdexcept>
 
 namespace common {
 
@@ -32,8 +31,7 @@ inline void save_npy_f32_1d(const std::string &path,
 
     std::ofstream ofs(path, std::ios::binary);
     if (!ofs)
-        throw art::Exception(art::errors::LogicError)
-            << "Cannot open " << path << " for writing";
+        throw std::runtime_error("Cannot open " + path + " for writing");
 
     ofs.write(magic, sizeof(magic) - 1);
     ofs.put(static_cast<char>(major));
@@ -43,21 +41,19 @@ inline void save_npy_f32_1d(const std::string &path,
     ofs.write(reinterpret_cast<const char *>(data.data()),
               static_cast<std::streamsize>(data.size() * sizeof(float)));
     if (!ofs)
-        throw art::Exception(art::errors::LogicError) << "Short write to " << path;
+        throw std::runtime_error("Short write to " + path);
 }
 
 inline void save_npy_f32_2d(const std::string &path,
                             const std::vector<std::vector<float>> &data) {
     if (data.empty())
-        throw art::Exception(art::errors::LogicError)
-            << "Cannot write empty array to " << path;
+        throw std::runtime_error("Cannot write empty array to " + path);
 
     size_t rows = data.size();
     size_t cols = data.front().size();
     for (const auto &row : data) {
         if (row.size() != cols)
-            throw art::Exception(art::errors::LogicError)
-                << "Inconsistent row size writing " << path;
+            throw std::runtime_error("Inconsistent row size writing " + path);
     }
 
     const char magic[] = "\x93NUMPY";
@@ -79,8 +75,7 @@ inline void save_npy_f32_2d(const std::string &path,
 
     std::ofstream ofs(path, std::ios::binary);
     if (!ofs)
-        throw art::Exception(art::errors::LogicError)
-            << "Cannot open " << path << " for writing";
+        throw std::runtime_error("Cannot open " + path + " for writing");
 
     ofs.write(magic, sizeof(magic) - 1);
     ofs.put(static_cast<char>(major));
@@ -93,7 +88,7 @@ inline void save_npy_f32_2d(const std::string &path,
                   static_cast<std::streamsize>(row.size() * sizeof(float)));
     }
     if (!ofs)
-        throw art::Exception(art::errors::LogicError) << "Short write to " << path;
+        throw std::runtime_error("Short write to " + path);
 }
 
 } // namespace common

--- a/Common/TruthLabelClassifier.h
+++ b/Common/TruthLabelClassifier.h
@@ -34,7 +34,6 @@
 #include "lardataobj/RecoBase/Vertex.h"
 #include "lardataobj/RecoBase/PFParticle.h"
 #include "lardataobj/RecoBase/Slice.h"
-#include "lardataobj/Simulation/SimChannel.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include <lardataobj/AnalysisBase/BackTrackerMatchingData.h>


### PR DESCRIPTION
## Summary
- Replace art::Exception with std::runtime_error in NpyUtils to drop art dependency
- Remove stray trailing character in HitProximityClustering header
- Drop unused SimChannel includes from analysis and common utilities

## Testing
- `g++ -fsyntax-only -std=c++17 Common/NpyUtils.h`
- `g++ -fsyntax-only -std=c++17 Common/HitProximityClustering.h` *(fails: lardataobj/RecoBase/Hit.h: No such file or directory)*
- `g++ -fsyntax-only -std=c++17 AnalysisTools/ImageAnalysis_tool.cc` *(fails: art/Utilities/ToolMacros.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b83f531d24832ea267f1c0c9d833b4