### PR TITLE
Remove unused art exception header

### DIFF
--- a/Common/NpyUtils.h
+++ b/Common/NpyUtils.h
@@ -1,8 +1,6 @@
 #ifndef COMMON_NPYUTILS_H
 #define COMMON_NPYUTILS_H
 
-#include "art/Utilities/Exception.h"
-
 #include <cstdint>
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
## Summary
- remove dependency on `art/Utilities/Exception.h` in NpyUtils

## Testing
- `cmake -S . -B build` (fails: Unknown CMake command "install_headers")


------
https://chatgpt.com/codex/tasks/task_e_68b84177f454832e9ebc6be310af06a2