### PR TITLE
Ensure compatibility with missing dependencies

### DIFF
--- a/AnalysisTools/EventWeightAnalysis_tool.cc
+++ b/AnalysisTools/EventWeightAnalysis_tool.cc
@@ -1,6 +1,8 @@
 #ifndef EVENTWEIGHT_ANALYSIS_CXX
 #define EVENTWEIGHT_ANALYSIS_CXX
 
+#include <map>
+
 #include "larsim/EventWeight/Base/MCEventWeight.h"
 
 #include "AnalysisToolBase.h"
@@ -10,7 +12,6 @@
 #include <cassert>
 #include <iostream>
 #include <limits>
-#include <map>
 #include <numeric>
 #include <string>
 #include <vector>

--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -46,7 +46,15 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#if __has_include(<filesystem>)
 #include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "filesystem support not available"
+#endif
 #include <fstream>
 #include <iomanip>
 #include <limits.h>
@@ -63,8 +71,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-namespace fs = std::filesystem;
 
 namespace analysis {
 


### PR DESCRIPTION
## Summary
- Include `<map>` before `MCEventWeight` to satisfy dependency ordering
- Provide portable filesystem includes with fallback to experimental implementation

## Testing
- `g++ -std=c++17 -fsyntax-only AnalysisTools/EventWeightAnalysis_tool.cc 2>&1 | head -n 20` *(fails: larsim/EventWeight/Base/MCEventWeight.h: No such file or directory)*
- `g++ -std=c++17 -fsyntax-only AnalysisTools/ImageAnalysis_tool.cc 2>&1 | head -n 20` *(fails: art/Framework/Principal/Event.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b842a1aa24832e8bad0722f637bc8e