### PR TITLE
chore: remove unused is_remote_url helper

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -68,11 +68,6 @@ namespace fs = std::filesystem;
 
 namespace analysis {
 
-static inline bool is_remote_url(const std::string &s) {
-  std::string_view sv{s};
-  return sv.starts_with("http:") || sv.starts_with("https:");
-}
-
 static inline bool is_pnfs(const std::string &s) {
   std::string_view sv{s};
   return sv.starts_with("/pnfs/") || sv.starts_with("/eos/") ||


### PR DESCRIPTION
## Summary
- drop unused `is_remote_url` helper from `ImageAnalysis_tool`

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*
- `make -C build` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84333b4e8832e920c4eeb31b12183