### PR TITLE
Tar build products on successful build

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+set -e
+
 export WRK_DIR=$(pwd)
-cd $MRB_TOP
+cd "$MRB_TOP"
 
 mrbsetenv
 mrb i -j8
 
-cd $WRK_DIR
+cd "$WRK_DIR"
 
+# Package the LArSoft local installation and assets if the build succeeds
+"$WRK_DIR/scripts/tar.sh"


### PR DESCRIPTION
## Summary
- Automatically tar LArSoft local install and assets at the end of `.build.sh`
- Enable early exit on build failure

## Testing
- `bash -n .build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b846ec14b4832ebf603c2f38ca72ad