### PR TITLE
Simplify filesystem include in ImageAnalysis tool

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -46,15 +46,8 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
-#if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error "filesystem support not available"
-#endif
 #include <fstream>
 #include <iomanip>
 #include <limits.h>


### PR DESCRIPTION
## Summary
- rely on standard <filesystem> without experimental fallback

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*


------
https://chatgpt.com/codex/tasks/task_e_68b84d870dac832eb3691e09a0cde4b2