### PR TITLE
Replace std::filesystem usage with POSIX dirent

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -46,8 +46,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
-#include <filesystem>
-namespace fs = std::filesystem;
+#include <dirent.h>
 #include <fstream>
 #include <iomanip>
 #include <limits.h>
@@ -174,13 +173,16 @@ void ImageAnalysis::configure(const fhicl::ParameterSet &p) {
         if (getcwd(cwd, sizeof(cwd))) {
             mf::LogInfo log("ImageAnalysis");
             log << "Job CWD: " << cwd << '\n';
-            try {
-                for (const auto &entry : fs::directory_iterator(cwd)) {
-                    log << "  " << entry.path().filename().string() << '\n';
+            DIR *dir = opendir(cwd);
+            if (dir) {
+                struct dirent *entry;
+                while ((entry = readdir(dir)) != nullptr) {
+                    log << "  " << entry->d_name << '\n';
                 }
-            } catch (const fs::filesystem_error &e) {
+                closedir(dir);
+            } else {
                 mf::LogWarning("ImageAnalysis")
-                    << "Unable to list directory contents: " << e.what();
+                    << "Unable to list directory contents";
             }
         }
     }


### PR DESCRIPTION
## Summary
- Drop dependency on C++17 `<filesystem>` in `ImageAnalysis_tool`
- Use `opendir`/`readdir` to log working directory contents

## Testing
- `cmake -S . -B build` (fails: Unknown CMake command "install_headers")

------
https://chatgpt.com/codex/tasks/task_e_68b852d16e8c832eab1784bc06b83378