### PR TITLE
Add filesystem support to ImageAnalysis tool

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -47,6 +47,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <dirent.h>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <limits.h>
@@ -61,6 +62,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+namespace fs = std::filesystem;
 
 namespace analysis {
 


### PR DESCRIPTION
## Summary
- include `<filesystem>` and define `fs` alias for weight path handling

## Testing
- `cmake ..` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b853fcd7b8832e8d946dd9c6e78538