### PR TITLE
Streamline asset path handling in ImageAnalysis tool

### DIFF
--- a/job/selectionconfig.fcl
+++ b/job/selectionconfig.fcl
@@ -85,6 +85,7 @@ FlashAnalysis: {
 
 ImageAnalysis: {
     tool_type: "ImageAnalysis"
+    AssetsBaseDir: "assets"           # env override: ASSETS_BASE_DIR
     PFPproducer: @local::standard_producers.PFPproducer
     CLSproducer: @local::standard_producers.CLSproducer
     HITproducer: @local::standard_producers.HITproducer
@@ -92,8 +93,9 @@ ImageAnalysis: {
     MCPproducer: @local::standard_producers.MCPproducer
     BKTproducer: @local::standard_producers.BKTproducer
     SLCproducer: @local::standard_producers.SLCproducer
-    BadChannelFile: "ubana/data/badchannels.txt"
-    WeightsBaseDir: "weights"
+    BadChannelFile: "calib/badchannels.txt"
+    WeightsBaseDir: "weights"         # env override: WEIGHTS_BASE_DIR
+    InferenceWrapper: "scripts/run_strangeness_inference.sh"
     imageWidth: 512
     imageHeight: 512
     Models: [
@@ -108,7 +110,7 @@ ImageAnalysis: {
             weights_file: "binary_classifier_resnet34.pth"
         }
     ]
-    ActiveModels: [ "binary", "binary_clone" ]
+    ActiveModels: [ "binary", "binary_clone" ]  # env override: ACTIVE_MODELS
 }
 
 SliceAnalysis: {


### PR DESCRIPTION
## Summary
- centralize asset lookup with helper functions and environment-aware resolver
- simplify inference and model weight path handling
- clarify FHiCL with single asset root and relative paths
- add initialization script that exports asset paths and related environment variables

## Testing
- `bash scripts/init_payload_paths.sh`
- `shellcheck scripts/init_payload_paths.sh` *(fails: command not found; apt-get update failed with 403)*
- `cmake -S . -B build` *(fails: Unknown CMake command `install_headers`)*

------
https://chatgpt.com/codex/tasks/task_e_68b859b1f4e0832e9ca818f5e30cbf49