### PR TITLE
Add script to package build and assets

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+set -e
 
 export WRK_DIR=$(pwd)
-cd $MRB_TOP
+cd "$MRB_TOP"
 
 mrbsetenv
 mrb i -j8
 
-cd $WRK_DIR
-
-"$WRK_DIR/scripts/tar.sh"
+cd "$WRK_DIR"
+"$WRK_DIR/tar_artifacts.sh"

--- a/tar_artifacts.sh
+++ b/tar_artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAR_DIR="${TAR_DIR:-/pnfs/uboone/scratch/users/${USER}/tarballs}"
+ASSETS_ROOT="${ASSETS_ROOT:-${SCRIPT_DIR}/assets}"
+BUILD_ROOT="${BUILD_ROOT:-${MRB_INSTALL:-${SRT_PRIVATE_CONTEXT:-${SCRIPT_DIR}}}}"
+
+mkdir -p "${TAR_DIR}"
+
+LAR_TAR="${TAR_DIR}/strangeness.tar"
+ASSETS_TAR="${TAR_DIR}/strangeness_assets.tar.gz"
+
+# Package the local LArSoft build
+if [[ -d "${BUILD_ROOT}" ]]; then
+  tar -C "${BUILD_ROOT}" -czf "${LAR_TAR}" . \
+    --exclude='.git' --exclude='tmp' --exclude='*.root'
+else
+  echo "WARNING: build directory '${BUILD_ROOT}' not found" >&2
+fi
+
+# Package the assets directory
+if [[ -d "${ASSETS_ROOT}" ]]; then
+  tar -C "${ASSETS_ROOT}" -czf "${ASSETS_TAR}" . \
+    --exclude='.git' --exclude='__pycache__' --exclude='*.pyc'
+else
+  echo "WARNING: assets directory '${ASSETS_ROOT}' not found" >&2
+fi
+
+echo "LArSoft tarball:  ${LAR_TAR}"
+echo "Assets tarball:  ${ASSETS_TAR}"


### PR DESCRIPTION
## Summary
- Add `tar_artifacts.sh` to archive LArSoft build and assets into user tarball directory
- Update `.build.sh` to run packaging script only after a successful build

## Testing
- `bash -n tar_artifacts.sh`
- `bash -n .build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b865d60f3c832ea23dae1b5a117a86