### PR TITLE
Fix NeutrinoSelectionFilter table directive in FCL

### DIFF
--- a/run_neutrinoselection.fcl
+++ b/run_neutrinoselection.fcl
@@ -33,7 +33,7 @@ source: {
 physics: {
     filters: {
         nuselection: {
-            @local::NeutrinoSelectionFilter
+            @table::NeutrinoSelectionFilter
             IsData: @is_data
         }
     }


### PR DESCRIPTION
## Summary
- use `@table::NeutrinoSelectionFilter` to include selection table

## Testing
- `lar -c run_neutrinoselection.fcl -T /tmp/test.root -n 0` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b889e741d0832ebf08bc729b3ddb63