### PR TITLE
Fix IsData reference in neutrino selection FHiCL

### DIFF
--- a/run_neutrinoselection.fcl
+++ b/run_neutrinoselection.fcl
@@ -34,7 +34,7 @@ physics: {
     filters: {
         nuselection: {
             @table::NeutrinoSelectionFilter
-            IsData: @is_data
+            IsData: @local::is_data
         }
     }
     path1: [ nuselection ]


### PR DESCRIPTION
## Summary
- Fix IsData setting in `run_neutrinoselection.fcl` to use `@local::is_data`

## Testing
- `cmake ..` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68b88bd82158832e866f7b163580e54c