### PR TITLE
Add default verbosity and data flags

### DIFF
--- a/EventSelectionFilter_module.cc
+++ b/EventSelectionFilter_module.cc
@@ -100,8 +100,8 @@ EventSelectionFilter::EventSelectionFilter(fhicl::ParameterSet const &p)
     fMCTproducer = p.get<art::InputTag>("MCTproducer");
     fWIREproducer = p.get<art::InputTag>("WIREproducer");
 
-    _verbose = p.get<bool>("Verbose");
-    _data = p.get<bool>("IsData");
+    _verbose = p.get<bool>("Verbose", false);
+    _data = p.get<bool>("IsData", false);
     _fake_data = p.get<bool>("IsFakeData", false);
     _filter = p.get<bool>("Filter", false);
 


### PR DESCRIPTION
## Summary
- Set default values for `Verbose` and `IsData` parameters in `EventSelectionFilter`

## Testing
- `./.test.sh run_neutrinoselection.fcl 1` *(fails: samweb: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8912bbba8832e8c71ece043aa514f