### PR TITLE
Add beam detvar CV workflow without inference

### DIFF
--- a/xml/numi_fhc_beam_detvar_cv_noinf.xml
+++ b/xml/numi_fhc_beam_detvar_cv_noinf.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE project [
+    <!ENTITY release "v08_00_00_82">
+    <!ENTITY user "nlane">
+    <!ENTITY name "nl_numi_fhc_run1_beam_cv">
+    <!ENTITY fcl_selection "run_neutrinoselection.fcl">
+    <!ENTITY initsrc "assets/scripts/initsrc.sh">
+
+    <!ENTITY tar_dir "/pnfs/uboone/scratch/users/nlane/tarballs">
+    <!ENTITY larsoft_tar "&tar_dir;/strangeness.tar">
+
+    <!ENTITY input_def_detvar_cv "prodgenie_numi_nu_overlay_v08_00_00_53_CV_300k_reco2_run1_reco2">
+]>
+
+<job>
+<project name="&name;">
+
+    <numevents>-1</numevents>
+    <os>SL7</os>
+    <resource>DEDICATED,OPPORTUNISTIC,OFFSITE</resource>
+    <larsoft>
+        <tag>&release;</tag>
+        <qual>e17:prof</qual>
+        <local>&larsoft_tar;</local>
+    </larsoft>
+    <check>1</check>
+    <copy>0</copy>
+    <version>prod_&release;</version>
+    <memory>6000</memory>
+    <disk>20GB</disk>
+    <schema>https</schema>
+    <maxfilesperjob>1</maxfilesperjob>
+
+    <stage name="selection_detvar_cv">
+        <inputdef>&input_def_detvar_cv;</inputdef>
+        <fcl>&fcl_selection; -a NeutrinoSelectionFilter.AnalysisTools.image.ActiveModels:=[]</fcl>
+        <initsource>&initsrc;</initsource>
+        <outdir>/pnfs/uboone/scratch/users/&user;/ntuples/&release;/&name;/detvar_cv/out</outdir>
+        <logdir>/pnfs/uboone/scratch/users/&user;/ntuples/&release;/&name;/detvar_cv/log</logdir>
+        <workdir>/pnfs/uboone/scratch/users/&user;/work/ntuples/&release;/&name;/detvar_cv</workdir>
+        <datatier>selected</datatier>
+        <numjobs>8000</numjobs>
+    </stage>
+
+</project>
+</job>


### PR DESCRIPTION
## Summary
- add standalone workflow XML for beam detector CV sample
- disable inference by passing empty ActiveModels list to the FHiCL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb137c6e30832e8ac5f441ef1fa01d