### PR TITLE
Add track-level dE/dx and deflection scaffolding

### DIFF
--- a/AnalysisTools/TrackAnalysis_tool.cc
+++ b/AnalysisTools/TrackAnalysis_tool.cc
@@ -15,8 +15,11 @@
 #include "Common/ProxyTypes.h"
 #include "Common/SpaceChargeCorrections.h"
 #include "Common/TrackShowerScore.h"
+#include "Common/Quantile.h"
 
-#include <cmath>
+#include <cmath>  // for std::isfinite
+#include <algorithm>
+#include <numeric>
 #include <iostream>
 #include <limits>
 
@@ -36,8 +39,24 @@ private:
     void fill_default();
     float calculate_track_trunk_dedx_by_hits(const std::vector<float>& dedx_values);
     float calculate_track_trunk_dedx_by_range(const std::vector<float>& dedx_values, const std::vector<float>& residual_range_values);
-    void calculate_track_deflections(const art::Ptr<recob::Track>& track, std::vector<float>& mean_deflections, 
+    float calculate_track_trunk_rr_qtrim(const std::vector<float>& dedx,
+                                         const std::vector<float>& rr,
+                                         float alpha=0.25f, float beta=0.75f,
+                                         unsigned skip_each_end=3,
+                                         double qlow=0.10, double qhigh=0.80,
+                                         unsigned min_hits_in_band=8);
+    void calculate_track_deflections(const art::Ptr<recob::Track>& track, std::vector<float>& mean_deflections,
                                    std::vector<float>& stdev_deflections, std::vector<float>& mean_separation);
+    void calculate_track_deflections_qtrim(const art::Ptr<recob::Track>& track,
+                                           std::vector<float>& mean_qtrim_out,
+                                           std::vector<float>& rms_qtrim_out,
+                                           std::vector<float>& q90_out,
+                                           std::vector<int>& njoints_mid_out,
+                                           float alpha=0.25f, float beta=0.75f,
+                                           unsigned skip_each_end=2,
+                                           double qlow=0.10, double qhigh=0.90,
+                                           float min_seg_cm=2.0f, float max_seg_cm=15.0f,
+                                           unsigned min_joints=5);
 
     art::InputTag fCALproducer;
     art::InputTag fTRKproducer;
@@ -85,12 +104,25 @@ private:
     std::vector<float> _track_trunk_rr_dedx_u;
     std::vector<float> _track_trunk_rr_dedx_v;
     std::vector<float> _track_trunk_rr_dedx_y;
+    // --- Track-level dE/dx (for downstream quantile fit) ---
+    std::vector<float> _track_tm_dedx;
+    std::vector<float> _track_tm_dedx_plane_spread;
+    std::vector<int>   _track_tm_dedx_nplanes;
+    // --- Scatter (for downstream standardisation/fit) ---
+    std::vector<int>   _track_mcs_njoints;
+    std::vector<float> _track_deflection_rms;
+    std::vector<float> _track_deflection_max;
     std::vector<int> _track_nhits_u;
     std::vector<int> _track_nhits_v;
     std::vector<int> _track_nhits_y;
     std::vector<float> _track_avg_deflection_mean;
     std::vector<float> _track_avg_deflection_stdev;
     std::vector<float> _track_avg_deflection_separation_mean;
+    // Deflection (angles) with middle-window + quantile trimming
+    std::vector<float> _track_deflection_mean_qtrim;
+    std::vector<float> _track_deflection_rms_qtrim;
+    std::vector<float> _track_deflection_q90;
+    std::vector<int>   _track_deflection_njoints_mid;
     std::vector<int> _track_end_spacepoints;
 
     std::vector<float> _trk_llr_pid_u_v;
@@ -223,6 +255,13 @@ void TrackAnalysis::analyseSlice(const art::Event& event, std::vector<common::Pr
             _trk_llr_pid_v.push_back(0.0f);
             _trk_llr_pid_score_v.push_back(std::numeric_limits<float>::lowest());
 
+            float trunk_by_hits[3] = { std::numeric_limits<float>::lowest(),
+                                       std::numeric_limits<float>::lowest(),
+                                       std::numeric_limits<float>::lowest() };
+            float trunk_by_rr[3]   = { std::numeric_limits<float>::lowest(),
+                                       std::numeric_limits<float>::lowest(),
+                                       std::numeric_limits<float>::lowest() };
+
             auto calorimetry_objects = calorimetry_proxy[track.key()].get<anab::Calorimetry>();
             for (const auto& calo : calorimetry_objects) {
                 int plane = calo->PlaneID().Plane;
@@ -251,7 +290,9 @@ void TrackAnalysis::analyseSlice(const art::Event& event, std::vector<common::Pr
 
                 float trk_nhits = static_cast<float>(dedx_values_corrected.size());
                 float trunk_dedx = calculate_track_trunk_dedx_by_hits(dedx_values_corrected);
-                float trunk_rr_dedx = calculate_track_trunk_dedx_by_range(dedx_values_corrected, residual_range);
+                float trunk_rr_dedx = calculate_track_trunk_rr_qtrim(
+                    dedx_values_corrected, residual_range,
+                    0.25f, 0.75f, 3, 0.10, 0.80, 8);
 
                 std::vector<std::vector<float>> par_values;
                 par_values.push_back(residual_range);
@@ -264,26 +305,62 @@ void TrackAnalysis::analyseSlice(const art::Event& event, std::vector<common::Pr
                     _track_nhits_u.push_back(trk_nhits);
                     _track_trunk_dedx_u.push_back(trunk_dedx);
                     _track_trunk_rr_dedx_u.push_back(trunk_rr_dedx);
+                    trunk_by_hits[0] = trunk_dedx;
+                    trunk_by_rr[0]   = trunk_rr_dedx;
                 } else if (plane == 1) {
                     _trk_llr_pid_v_v.back() = llr_pid;
                     _track_calo_energy_v.push_back(calo_energy);
                     _track_nhits_v.push_back(trk_nhits);
                     _track_trunk_dedx_v.push_back(trunk_dedx);
                     _track_trunk_rr_dedx_v.push_back(trunk_rr_dedx);
+                    trunk_by_hits[1] = trunk_dedx;
+                    trunk_by_rr[1]   = trunk_rr_dedx;
                 } else if (plane == 2) {
                     _trk_llr_pid_y_v.back() = llr_pid;
                     _track_calo_energy_y.push_back(calo_energy);
                     _track_nhits_y.push_back(trk_nhits);
                     _track_trunk_dedx_y.push_back(trunk_dedx);
                     _track_trunk_rr_dedx_y.push_back(trunk_rr_dedx);
+                    trunk_by_hits[2] = trunk_dedx;
+                    trunk_by_rr[2]   = trunk_rr_dedx;
                 }
                 _trk_llr_pid_v.back() += llr_pid;
+            }
+
+            auto valid = [](float x){
+              return std::isfinite(x) && x != std::numeric_limits<float>::lowest();
+            };
+
+            std::vector<float> candidates;
+            candidates.reserve(3);
+            for (int i=0;i<3;++i) {
+              if (valid(trunk_by_rr[i]))   candidates.push_back(trunk_by_rr[i]);
+              else if (valid(trunk_by_hits[i])) candidates.push_back(trunk_by_hits[i]);
+            }
+
+            if (candidates.size() >= 2) {
+              std::sort(candidates.begin(), candidates.end());
+              float median_tm = (candidates.size()==2) ? 0.5f*(candidates[0]+candidates[1])
+                                                      : candidates[candidates.size()/2];
+              float plane_spread = candidates.back() - candidates.front();
+              _track_tm_dedx.push_back(median_tm);
+              _track_tm_dedx_plane_spread.push_back(plane_spread);
+              _track_tm_dedx_nplanes.push_back(static_cast<int>(candidates.size()));
+            } else {
+              _track_tm_dedx.push_back(std::numeric_limits<float>::lowest());
+              _track_tm_dedx_plane_spread.push_back(std::numeric_limits<float>::lowest());
+              _track_tm_dedx_nplanes.push_back(std::numeric_limits<int>::lowest());
             }
 
             _trk_llr_pid_score_v.back() = atan(_trk_llr_pid_v.back() / 100.f) * 2 / 3.14159266f;
 
             calculate_track_deflections(track, _track_avg_deflection_mean, _track_avg_deflection_stdev,
                                        _track_avg_deflection_separation_mean);
+            calculate_track_deflections_qtrim(track,
+                                             _track_deflection_mean_qtrim,
+                                             _track_deflection_rms_qtrim,
+                                             _track_deflection_q90,
+                                             _track_deflection_njoints_mid);
 
             int end_spacepoint_count = 0;
             float distance_squared = fEndSpacepointDistance * fEndSpacepointDistance;
@@ -333,12 +410,22 @@ void TrackAnalysis::fill_default() {
     _track_trunk_rr_dedx_u.push_back(std::numeric_limits<float>::lowest());
     _track_trunk_rr_dedx_v.push_back(std::numeric_limits<float>::lowest());
     _track_trunk_rr_dedx_y.push_back(std::numeric_limits<float>::lowest());
+    _track_tm_dedx.push_back(std::numeric_limits<float>::lowest());
+    _track_tm_dedx_plane_spread.push_back(std::numeric_limits<float>::lowest());
+    _track_tm_dedx_nplanes.push_back(std::numeric_limits<int>::lowest());
+    _track_mcs_njoints.push_back(std::numeric_limits<int>::lowest());
+    _track_deflection_rms.push_back(std::numeric_limits<float>::lowest());
+    _track_deflection_max.push_back(std::numeric_limits<float>::lowest());
     _track_nhits_u.push_back(std::numeric_limits<int>::lowest());
     _track_nhits_v.push_back(std::numeric_limits<int>::lowest());
     _track_nhits_y.push_back(std::numeric_limits<int>::lowest());
     _track_avg_deflection_mean.push_back(std::numeric_limits<float>::lowest());
     _track_avg_deflection_stdev.push_back(std::numeric_limits<float>::lowest());
     _track_avg_deflection_separation_mean.push_back(std::numeric_limits<float>::lowest());
+    _track_deflection_mean_qtrim.push_back(std::numeric_limits<float>::lowest());
+    _track_deflection_rms_qtrim.push_back(std::numeric_limits<float>::lowest());
+    _track_deflection_q90.push_back(std::numeric_limits<float>::lowest());
+    _track_deflection_njoints_mid.push_back(std::numeric_limits<int>::lowest());
     _track_end_spacepoints.push_back(std::numeric_limits<int>::lowest());
     _trk_llr_pid_u_v.push_back(std::numeric_limits<float>::lowest());
     _trk_llr_pid_v_v.push_back(std::numeric_limits<float>::lowest());
@@ -377,12 +464,22 @@ void TrackAnalysis::setBranches(TTree* tree) {
     tree->Branch("track_trunk_rr_dedx_u", "std::vector<float>", &_track_trunk_rr_dedx_u);
     tree->Branch("track_trunk_rr_dedx_v", "std::vector<float>", &_track_trunk_rr_dedx_v);
     tree->Branch("track_trunk_rr_dedx_y", "std::vector<float>", &_track_trunk_rr_dedx_y);
+    tree->Branch("track_tm_dedx", "std::vector<float>", &_track_tm_dedx);
+    tree->Branch("track_tm_dedx_plane_spread", "std::vector<float>", &_track_tm_dedx_plane_spread);
+    tree->Branch("track_tm_dedx_nplanes", "std::vector<int>", &_track_tm_dedx_nplanes);
+    tree->Branch("track_mcs_njoints", "std::vector<int>", &_track_mcs_njoints);
+    tree->Branch("track_deflection_rms", "std::vector<float>", &_track_deflection_rms);
+    tree->Branch("track_deflection_max", "std::vector<float>", &_track_deflection_max);
     tree->Branch("track_nhits_u", "std::vector<int>", &_track_nhits_u);
     tree->Branch("track_nhits_v", "std::vector<int>", &_track_nhits_v);
     tree->Branch("track_nhits_y", "std::vector<int>", &_track_nhits_y);
     tree->Branch("track_avg_deflection_mean", "std::vector<float>", &_track_avg_deflection_mean);
     tree->Branch("track_avg_deflection_stdev", "std::vector<float>", &_track_avg_deflection_stdev);
     tree->Branch("track_avg_deflection_separation_mean", "std::vector<float>", &_track_avg_deflection_separation_mean);
+    tree->Branch("track_deflection_mean_qtrim", "std::vector<float>", &_track_deflection_mean_qtrim);
+    tree->Branch("track_deflection_rms_qtrim", "std::vector<float>", &_track_deflection_rms_qtrim);
+    tree->Branch("track_deflection_q90", "std::vector<float>", &_track_deflection_q90);
+    tree->Branch("track_deflection_njoints_mid", "std::vector<int>", &_track_deflection_njoints_mid);
     tree->Branch("track_end_spacepoints", "std::vector<int>", &_track_end_spacepoints);
     tree->Branch("trk_llr_pid_u", "std::vector<float>", &_trk_llr_pid_u_v);
     tree->Branch("trk_llr_pid_v", "std::vector<float>", &_trk_llr_pid_v_v);
@@ -421,12 +518,22 @@ void TrackAnalysis::resetTTree(TTree* tree) {
     _track_trunk_rr_dedx_u.clear();
     _track_trunk_rr_dedx_v.clear();
     _track_trunk_rr_dedx_y.clear();
+    _track_tm_dedx.clear();
+    _track_tm_dedx_plane_spread.clear();
+    _track_tm_dedx_nplanes.clear();
+    _track_mcs_njoints.clear();
+    _track_deflection_rms.clear();
+    _track_deflection_max.clear();
     _track_nhits_u.clear();
     _track_nhits_v.clear();
     _track_nhits_y.clear();
     _track_avg_deflection_mean.clear();
     _track_avg_deflection_stdev.clear();
     _track_avg_deflection_separation_mean.clear();
+    _track_deflection_mean_qtrim.clear();
+    _track_deflection_rms_qtrim.clear();
+    _track_deflection_q90.clear();
+    _track_deflection_njoints_mid.clear();
     _track_end_spacepoints.clear();
     _trk_llr_pid_u_v.clear();
     _trk_llr_pid_v_v.clear();
@@ -476,7 +583,7 @@ float TrackAnalysis::calculate_track_trunk_dedx_by_hits(const std::vector<float>
     return static_cast<float>(trimmed_sum / trimmed_dedx_values.size());
 }
 
-float TrackAnalysis::calculate_track_trunk_dedx_by_range(const std::vector<float>& dedx_values, 
+float TrackAnalysis::calculate_track_trunk_dedx_by_range(const std::vector<float>& dedx_values,
                                                    const std::vector<float>& residual_range_values) {
     const unsigned int hits_to_skip = 3;
     const float length_fraction = 1.0f / 3.0f;
@@ -526,8 +633,56 @@ float TrackAnalysis::calculate_track_trunk_dedx_by_range(const std::vector<float
         }
     }
 
-    return (truncated_hit_count == 0) ? std::numeric_limits<float>::lowest() 
+    return (truncated_hit_count == 0) ? std::numeric_limits<float>::lowest()
                                    : truncated_total / static_cast<float>(truncated_hit_count);
+}
+
+float TrackAnalysis::calculate_track_trunk_rr_qtrim(
+    const std::vector<float>& dedx,
+    const std::vector<float>& rr,
+    float alpha, float beta,
+    unsigned skip_each_end,
+    double qlow, double qhigh,
+    unsigned min_hits_in_band) {
+    if (dedx.size() != rr.size() || dedx.empty())
+        return std::numeric_limits<float>::lowest();
+
+    std::vector<size_t> idx(rr.size());
+    std::iota(idx.begin(), idx.end(), 0);
+    std::stable_sort(idx.begin(), idx.end(),
+        [&](size_t a, size_t b){ return rr[a] > rr[b]; });
+
+    float rrmax = *std::max_element(rr.begin(), rr.end());
+    if (!(rrmax > 0)) return std::numeric_limits<float>::lowest();
+    float lo_cut = alpha * rrmax;
+    float hi_cut = beta  * rrmax;
+
+    std::vector<float> vals;
+    vals.reserve(dedx.size());
+    for (size_t k = 0; k < idx.size(); ++k) {
+        if (k < skip_each_end) continue;
+        if (k >= idx.size() - skip_each_end) continue;
+        size_t i = idx[k];
+        float r = rr[i];
+        if (r < lo_cut || r > hi_cut) continue;
+        float v = dedx[i];
+        if (std::isfinite(v)) vals.push_back(v);
+    }
+
+    if (vals.size() < min_hits_in_band)
+        return std::numeric_limits<float>::lowest();
+
+    float q_lo = common::quantile_linear(vals, qlow);
+    float q_hi = common::quantile_linear(vals, qhigh);
+    if (!(q_lo <= q_hi)) return std::numeric_limits<float>::lowest();
+
+    double sum = 0.0; unsigned n = 0;
+    for (float v : vals) {
+        if (v < q_lo || v > q_hi) continue;
+        sum += v; ++n;
+    }
+    if (n == 0) return std::numeric_limits<float>::lowest();
+    return static_cast<float>(sum / n);
 }
 
 void TrackAnalysis::calculate_track_deflections(const art::Ptr<recob::Track>& track, 
@@ -547,6 +702,9 @@ void TrackAnalysis::calculate_track_deflections(const art::Ptr<recob::Track>& tr
         mean_deflections.push_back(std::numeric_limits<float>::lowest());
         stdev_deflections.push_back(std::numeric_limits<float>::lowest());
         mean_separation.push_back(std::numeric_limits<float>::lowest());
+        _track_mcs_njoints.push_back(std::numeric_limits<int>::lowest());
+        _track_deflection_rms.push_back(std::numeric_limits<float>::lowest());
+        _track_deflection_max.push_back(std::numeric_limits<float>::lowest());
         return;
     }
 
@@ -577,10 +735,162 @@ void TrackAnalysis::calculate_track_deflections(const art::Ptr<recob::Track>& tr
         variance_sum += (angle - mean_angle) * (angle - mean_angle);
     }
     float variance = variance_sum / (deflection_angles.size() - 1);
+    const int J = static_cast<int>(deflection_angles.size());
+    float sum_theta2 = 0.0f;
+    float theta_max  = 0.0f;
+    for (const auto& th : deflection_angles) {
+        sum_theta2 += th*th;
+        theta_max   = std::max(theta_max, th);
+    }
+    float theta_rms = (J>0) ? std::sqrt(sum_theta2 / J) : std::numeric_limits<float>::lowest();
 
     mean_deflections.push_back(mean_angle);
     stdev_deflections.push_back(std::sqrt(variance));
     mean_separation.push_back(mean_sep);
+    _track_mcs_njoints.push_back((J>0) ? J : std::numeric_limits<int>::lowest());
+    _track_deflection_rms.push_back(theta_rms);
+    _track_deflection_max.push_back((J>0) ? theta_max : std::numeric_limits<float>::lowest());
+}
+
+void TrackAnalysis::calculate_track_deflections_qtrim(
+    const art::Ptr<recob::Track>& track,
+    std::vector<float>& mean_qtrim_out,
+    std::vector<float>& rms_qtrim_out,
+    std::vector<float>& q90_out,
+    std::vector<int>& njoints_mid_out,
+    float alpha, float beta,
+    unsigned skip_each_end,
+    double qlow, double qhigh,
+    float min_seg_cm, float max_seg_cm,
+    unsigned min_joints) {
+    std::vector<size_t> vtx;
+    size_t i0 = track->FirstValidPoint();
+    if (i0 == recob::TrackTrajectory::InvalidIndex) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+    vtx.push_back(i0);
+    size_t inext = track->NextValidPoint(i0 + 1);
+    while (inext != recob::TrackTrajectory::InvalidIndex) {
+        vtx.push_back(inext);
+        inext = track->NextValidPoint(inext + 1);
+    }
+    if (vtx.size() < 3) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+
+    std::vector<float> s(vtx.size(), 0.0f);
+    for (size_t k=1; k<vtx.size(); ++k) {
+        TVector3 a(track->LocationAtPoint(vtx[k-1]).X(),
+                   track->LocationAtPoint(vtx[k-1]).Y(),
+                   track->LocationAtPoint(vtx[k-1]).Z());
+        TVector3 b(track->LocationAtPoint(vtx[k]).X(),
+                   track->LocationAtPoint(vtx[k]).Y(),
+                   track->LocationAtPoint(vtx[k]).Z());
+        s[k] = s[k-1] + (b-a).Mag();
+    }
+    const float Ltot = s.back();
+    if (!(Ltot > 0)) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+
+    const float slo = alpha * Ltot;
+    const float shi = beta  * Ltot;
+
+    struct Joint { float mid_s; float theta; };
+    std::vector<Joint> joints;
+    joints.reserve(vtx.size());
+    for (size_t k=1; k<vtx.size(); ++k) {
+        const auto u = track->DirectionAtPoint(vtx[k-1]).Unit();
+        const auto v = track->DirectionAtPoint(vtx[k]).Unit();
+        float cosang = std::min(1.0f, std::max(-1.0f, static_cast<float>(u.Dot(v))));
+        float theta = std::acos(cosang);
+
+        TVector3 a(track->LocationAtPoint(vtx[k-1]).X(),
+                   track->LocationAtPoint(vtx[k-1]).Y(),
+                   track->LocationAtPoint(vtx[k-1]).Z());
+        TVector3 b(track->LocationAtPoint(vtx[k]).X(),
+                   track->LocationAtPoint(vtx[k]).Y(),
+                   track->LocationAtPoint(vtx[k]).Z());
+        float ell = (b-a).Mag();
+        if (ell < min_seg_cm || ell > max_seg_cm) continue;
+
+        float smid = 0.5f * (s[k-1] + s[k]);
+        if (smid < slo || smid > shi) continue;
+
+        joints.push_back({smid, theta});
+    }
+
+    if (joints.size() < min_joints) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+
+    std::sort(joints.begin(), joints.end(),
+              [](const Joint& A, const Joint& B){ return A.mid_s < B.mid_s; });
+    size_t start = std::min<size_t>(skip_each_end, joints.size());
+    size_t stop  = (joints.size() > skip_each_end) ? joints.size() - skip_each_end : start;
+    if (stop <= start) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+
+    std::vector<float> th;
+    th.reserve(stop - start);
+    for (size_t k=start; k<stop; ++k) th.push_back(joints[k].theta);
+
+    float q_lo = common::quantile_linear(th, qlow);
+    float q_hi = common::quantile_linear(th, qhigh);
+    if (!(q_lo <= q_hi)) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+
+    double sum=0.0, sum2=0.0; unsigned n=0;
+    std::vector<float> kept; kept.reserve(th.size());
+    for (float t : th) {
+        if (t < q_lo || t > q_hi) continue;
+        kept.push_back(t);
+        sum  += t;
+        sum2 += t*t;
+        ++n;
+    }
+    if (n==0) {
+        mean_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        rms_qtrim_out.push_back(std::numeric_limits<float>::lowest());
+        q90_out.push_back(std::numeric_limits<float>::lowest());
+        njoints_mid_out.push_back(std::numeric_limits<int>::lowest());
+        return;
+    }
+
+    float mean_qtrim = static_cast<float>(sum / n);
+    float rms_qtrim  = static_cast<float>(std::sqrt(sum2 / n));
+    float q90        = common::quantile_linear(kept, 0.90);
+
+    mean_qtrim_out.push_back(mean_qtrim);
+    rms_qtrim_out.push_back(rms_qtrim);
+    q90_out.push_back(q90);
+    njoints_mid_out.push_back(static_cast<int>(n));
 }
 
 DEFINE_ART_CLASS_TOOL(TrackAnalysis)

--- a/Common/Quantile.h
+++ b/Common/Quantile.h
@@ -1,0 +1,31 @@
+#ifndef COMMON_QUANTILE_H
+#define COMMON_QUANTILE_H
+
+#include <algorithm>
+#include <vector>
+#include <cmath>
+#include <limits>
+
+namespace common {
+
+template<typename T>
+inline T clamp(T v, T lo, T hi) { return std::max(lo, std::min(v, hi)); }
+
+inline float quantile_linear(std::vector<float> v, double p) {
+    if (v.empty()) return std::numeric_limits<float>::quiet_NaN();
+    p = clamp(p, 0.0, 1.0);
+    double pos = p * (v.size() - 1);
+    size_t lo = static_cast<size_t>(std::floor(pos));
+    size_t hi = static_cast<size_t>(std::ceil(pos));
+    std::nth_element(v.begin(), v.begin() + lo, v.end());
+    float qlo = v[lo];
+    if (hi == lo) return qlo;
+    std::nth_element(v.begin(), v.begin() + hi, v.end());
+    float qhi = v[hi];
+    double frac = pos - lo;
+    return static_cast<float>((1.0 - frac) * qlo + frac * qhi);
+}
+
+} // namespace common
+
+#endif // COMMON_QUANTILE_H


### PR DESCRIPTION
## Summary
- record median track dE/dx with plane spread and plane count
- expose scattering scaffolding including joint count, RMS and max deflection
- add quantile-trimmed deflection estimates for robust angular summaries
- factor quantile helper into reusable common header

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc14c4e010832e8837b87347a799e3