### PR TITLE
Use quiet NaN for unset float values

### DIFF
--- a/AnalysisTools/BlipAnalysis_tool.cc
+++ b/AnalysisTools/BlipAnalysis_tool.cc
@@ -21,6 +21,7 @@
 #include "TDatabasePDG.h"
 #include "TParticlePDG.h"
 #include <iostream>
+#include <limits>
 
 namespace analysis {
 
@@ -166,26 +167,26 @@ void BlipAnalysis::fillDefault() {
     _blip_tpc.push_back(std::numeric_limits<int>::lowest());
     _blip_n_planes.push_back(std::numeric_limits<int>::lowest());
     _blip_max_wire_span.push_back(std::numeric_limits<int>::lowest());
-    _blip_energy.push_back(std::numeric_limits<float>::lowest());
-    _blip_energy_estar.push_back(std::numeric_limits<float>::lowest());
-    _blip_time.push_back(std::numeric_limits<float>::lowest());
-    _blip_prox_trk_dist.push_back(std::numeric_limits<float>::lowest());
+    _blip_energy.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_energy_estar.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_time.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_prox_trk_dist.push_back(std::numeric_limits<float>::quiet_NaN());
     _blip_prox_trk_id.push_back(std::numeric_limits<int>::lowest());
     _blip_in_cylinder.push_back(false);
-    _blip_x.push_back(std::numeric_limits<float>::lowest());
-    _blip_y.push_back(std::numeric_limits<float>::lowest());
-    _blip_z.push_back(std::numeric_limits<float>::lowest());
-    _blip_sigma_yz.push_back(std::numeric_limits<float>::lowest());
-    _blip_dx.push_back(std::numeric_limits<float>::lowest());
-    _blip_dyz.push_back(std::numeric_limits<float>::lowest());
-    _blip_charge.push_back(std::numeric_limits<float>::lowest());
+    _blip_x.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_z.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_sigma_yz.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_dx.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_dyz.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_charge.push_back(std::numeric_limits<float>::quiet_NaN());
     _blip_pdg.push_back(std::numeric_limits<int>::lowest());
     _blip_process.push_back("null");
-    _blip_vx.push_back(std::numeric_limits<float>::lowest());
-    _blip_vy.push_back(std::numeric_limits<float>::lowest());
-    _blip_vz.push_back(std::numeric_limits<float>::lowest());
-    _blip_e.push_back(std::numeric_limits<float>::lowest());
-    _blip_mass.push_back(std::numeric_limits<float>::lowest());
+    _blip_vx.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_vy.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_vz.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_e.push_back(std::numeric_limits<float>::quiet_NaN());
+    _blip_mass.push_back(std::numeric_limits<float>::quiet_NaN());
     _blip_trk_id.push_back(std::numeric_limits<int>::lowest());
 }
 

--- a/AnalysisTools/DefaultAnalysis_tool.cc
+++ b/AnalysisTools/DefaultAnalysis_tool.cc
@@ -27,6 +27,8 @@
 #include "TDatabasePDG.h"
 #include "TParticlePDG.h"
 #include <iostream>
+#include <limits>
+#include <cmath>
 
 namespace analysis {
 
@@ -196,7 +198,7 @@ void DefaultAnalysis::analyseEvent(const art::Event &event, bool is_data) {
     }
 
     std::vector<float> temp_slice_topo_score_v(max_slice_id + 1);
-    fill(temp_slice_topo_score_v.begin(), temp_slice_topo_score_v.end(), std::numeric_limits<float>::lowest());
+    fill(temp_slice_topo_score_v.begin(), temp_slice_topo_score_v.end(), std::numeric_limits<float>::quiet_NaN());
     for (const common::ProxySliceElem_t &pfp : pfp_proxy) {
         auto metadata_pxy_v = pfp.get<larpandoraobj::PFParticleMetadata>();
         auto slice_pxy_v = pfp.get<recob::Slice>();
@@ -206,7 +208,7 @@ void DefaultAnalysis::analyseEvent(const art::Event &event, bool is_data) {
                 for (unsigned int j = 0; j < metadata_pxy_v.size(); ++j) {
                     const art::Ptr<larpandoraobj::PFParticleMetadata> &pfParticleMetadata(metadata_pxy_v.at(j));
                     auto pfParticlePropertiesMap = pfParticleMetadata->GetPropertiesMap();
-                    if (!pfParticlePropertiesMap.empty() && temp_slice_topo_score_v.at(pfp_slice_id) == std::numeric_limits<float>::lowest()) {
+                    if (!pfParticlePropertiesMap.empty() && std::isnan(temp_slice_topo_score_v.at(pfp_slice_id))) {
                         auto it = pfParticlePropertiesMap.begin();
                         while (it != pfParticlePropertiesMap.end()) {
                             if (it->first == "NuScore") {
@@ -397,9 +399,9 @@ void DefaultAnalysis::analyseSlice(const art::Event &event, std::vector<common::
             _pfp_vertex_z.push_back(vertices.at(0)->position().Z());
         }
         else {
-            _pfp_vertex_x.push_back(std::numeric_limits<float>::lowest());
-            _pfp_vertex_y.push_back(std::numeric_limits<float>::lowest());
-            _pfp_vertex_z.push_back(std::numeric_limits<float>::lowest());
+            _pfp_vertex_x.push_back(std::numeric_limits<float>::quiet_NaN());
+            _pfp_vertex_y.push_back(std::numeric_limits<float>::quiet_NaN());
+            _pfp_vertex_z.push_back(std::numeric_limits<float>::quiet_NaN());
         }
         
         float track_shower_score = common::GetTrackShowerScore(pfp);
@@ -509,28 +511,28 @@ void DefaultAnalysis::analyseSlice(const art::Event &event, std::vector<common::
                     _backtracked_sce_start_wire_Y.push_back(common::YZtoPlanecoordinate(reco_st[1], reco_st[2], 2));
                 }
                 else {
-                    _backtracked_energies.push_back(std::numeric_limits<float>::lowest());
+                    _backtracked_energies.push_back(std::numeric_limits<float>::quiet_NaN());
                     _backtracked_track_ids.push_back(std::numeric_limits<int>::lowest());
                     _backtracked_pdg_codes.push_back(0);
-                    _backtracked_purities.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_completenesses.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_overlay_purities.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_momentum_x.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_momentum_y.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_momentum_z.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_x.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_y.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_z.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_time.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_wire_U.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_wire_V.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_start_wire_Y.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_sce_start_x.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_sce_start_y.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_sce_start_z.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_sce_start_wire_U.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_sce_start_wire_V.push_back(std::numeric_limits<float>::lowest());
-                    _backtracked_sce_start_wire_Y.push_back(std::numeric_limits<float>::lowest());
+                    _backtracked_purities.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_completenesses.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_overlay_purities.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_momentum_x.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_momentum_y.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_momentum_z.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_x.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_y.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_z.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_time.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_wire_U.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_wire_V.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_start_wire_Y.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_sce_start_x.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_sce_start_y.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_sce_start_z.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_sce_start_wire_U.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_sce_start_wire_V.push_back(std::numeric_limits<float>::quiet_NaN());
+                    _backtracked_sce_start_wire_Y.push_back(std::numeric_limits<float>::quiet_NaN());
                 }
             }
         }
@@ -643,12 +645,12 @@ void DefaultAnalysis::resetTTree(TTree *_tree) {
     _selection_pass = 0;
     _optical_filter_pe_beam = 0.;
     _optical_filter_pe_veto = 0.;
-    _reco_neutrino_vertex_x = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_y = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_z = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_sce_x = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_sce_y = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_sce_z = std::numeric_limits<float>::lowest();
+    _reco_neutrino_vertex_x = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_y = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_z = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_sce_x = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_sce_y = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_sce_z = std::numeric_limits<float>::quiet_NaN();
     _num_slices = 0;
     _crt_veto = 0;
     _crt_hit_pe = 0;
@@ -683,7 +685,7 @@ void DefaultAnalysis::resetTTree(TTree *_tree) {
     _event_total_hits = std::numeric_limits<int>::lowest();
     _slice_pdg = std::numeric_limits<int>::lowest();
     _slice_id = std::numeric_limits<int>::lowest();
-    _topological_score = std::numeric_limits<float>::lowest();
+    _topological_score = std::numeric_limits<float>::quiet_NaN();
     _slice_topological_scores.clear();
     _slice_num_hits = std::numeric_limits<int>::lowest();
     _pfp_pdg_codes.clear();
@@ -704,7 +706,7 @@ void DefaultAnalysis::resetTTree(TTree *_tree) {
     _pfp_vertex_x.clear();
     _pfp_vertex_y.clear();
     _pfp_vertex_z.clear();
-    _slice_cluster_fraction = std::numeric_limits<float>::lowest();
+    _slice_cluster_fraction = std::numeric_limits<float>::quiet_NaN();
     _total_hits_U = 0;
     _total_hits_V = 0;
     _total_hits_Y = 0;

--- a/AnalysisTools/EnergyAnalysis_tool.cc
+++ b/AnalysisTools/EnergyAnalysis_tool.cc
@@ -13,6 +13,7 @@
 #include "Common/TrackShowerScore.h"
 
 #include <iostream>
+#include <limits>
 
 namespace analysis {
 
@@ -136,12 +137,12 @@ void EnergyAnalysis::setBranches(TTree* _tree) {
 }
 
 void EnergyAnalysis::resetTTree(TTree* _tree) {
-    _neutrino_energy_0 = std::numeric_limits<float>::lowest();
-    _neutrino_energy_1 = std::numeric_limits<float>::lowest();
-    _neutrino_energy_2 = std::numeric_limits<float>::lowest();
-    _slice_calo_energy_0 = std::numeric_limits<float>::lowest();
-    _slice_calo_energy_1 = std::numeric_limits<float>::lowest();
-    _slice_calo_energy_2 = std::numeric_limits<float>::lowest();
+    _neutrino_energy_0 = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_energy_1 = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_energy_2 = std::numeric_limits<float>::quiet_NaN();
+    _slice_calo_energy_0 = std::numeric_limits<float>::quiet_NaN();
+    _slice_calo_energy_1 = std::numeric_limits<float>::quiet_NaN();
+    _slice_calo_energy_2 = std::numeric_limits<float>::quiet_NaN();
 }
 
 DEFINE_ART_CLASS_TOOL(EnergyAnalysis)

--- a/AnalysisTools/FlashAnalysis_tool.cc
+++ b/AnalysisTools/FlashAnalysis_tool.cc
@@ -12,6 +12,7 @@
 #include "lardataobj/RecoBase/Slice.h"
 
 #include "AnalysisToolBase.h"
+#include <limits>
 
 namespace analysis {
 
@@ -67,17 +68,17 @@ void FlashAnalysis::setBranches(TTree* tree) {
 }
 
 void FlashAnalysis::resetTTree(TTree* tree) {
-    _t0 = std::numeric_limits<float>::lowest();
-    _flash_match_score = std::numeric_limits<float>::lowest();
-    _flash_total_pe = std::numeric_limits<float>::lowest();
-    _flash_time = std::numeric_limits<float>::lowest();
-    _flash_z_center = std::numeric_limits<float>::lowest();
-    _flash_z_width = std::numeric_limits<float>::lowest();
-    _slice_charge = std::numeric_limits<float>::lowest();
-    _slice_z_center = std::numeric_limits<float>::lowest();
-    _charge_light_ratio = std::numeric_limits<float>::lowest();
-    _flash_slice_z_dist = std::numeric_limits<float>::lowest();
-    _flash_pe_per_charge = std::numeric_limits<float>::lowest();
+    _t0 = std::numeric_limits<float>::quiet_NaN();
+    _flash_match_score = std::numeric_limits<float>::quiet_NaN();
+    _flash_total_pe = std::numeric_limits<float>::quiet_NaN();
+    _flash_time = std::numeric_limits<float>::quiet_NaN();
+    _flash_z_center = std::numeric_limits<float>::quiet_NaN();
+    _flash_z_width = std::numeric_limits<float>::quiet_NaN();
+    _slice_charge = std::numeric_limits<float>::quiet_NaN();
+    _slice_z_center = std::numeric_limits<float>::quiet_NaN();
+    _charge_light_ratio = std::numeric_limits<float>::quiet_NaN();
+    _flash_slice_z_dist = std::numeric_limits<float>::quiet_NaN();
+    _flash_pe_per_charge = std::numeric_limits<float>::quiet_NaN();
 }
 
 void FlashAnalysis::analyseSlice(const art::Event& event, std::vector<common::ProxyPfpElem_t>& slice_pfp_vec, bool is_data, bool is_selected) {

--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -340,9 +340,9 @@ void ImageAnalysis::setBranches(TTree *_tree) {
 }
 
 void ImageAnalysis::resetTTree(TTree *_tree) {
-    _reco_neutrino_vertex_x = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_y = std::numeric_limits<float>::lowest();
-    _reco_neutrino_vertex_z = std::numeric_limits<float>::lowest();
+    _reco_neutrino_vertex_x = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_y = std::numeric_limits<float>::quiet_NaN();
+    _reco_neutrino_vertex_z = std::numeric_limits<float>::quiet_NaN();
     _detector_image_u.clear();
     _detector_image_v.clear();
     _detector_image_w.clear();
@@ -355,9 +355,9 @@ void ImageAnalysis::resetTTree(TTree *_tree) {
     _event_semantic_image_u.clear();
     _event_semantic_image_v.clear();
     _event_semantic_image_w.clear();
-    _event_adc_u = std::numeric_limits<float>::lowest();
-    _event_adc_v = std::numeric_limits<float>::lowest();
-    _event_adc_w = std::numeric_limits<float>::lowest();
+    _event_adc_u = std::numeric_limits<float>::quiet_NaN();
+    _event_adc_v = std::numeric_limits<float>::quiet_NaN();
+    _event_adc_w = std::numeric_limits<float>::quiet_NaN();
     _slice_semantic_counts_u.clear();
     _slice_semantic_counts_v.clear();
     _slice_semantic_counts_w.clear();
@@ -494,7 +494,7 @@ void ImageAnalysis::analyseSlice(const art::Event &event, std::vector<common::Pr
         _inference_scores[m.name] = score;
     }
 
-    if (_reco_neutrino_vertex_x != std::numeric_limits<float>::lowest()) {
+    if (!std::isnan(_reco_neutrino_vertex_x)) {
         TVector3 vtx_pos_3d(_reco_neutrino_vertex_x, _reco_neutrino_vertex_y,
                             _reco_neutrino_vertex_z);
         TVector3 vtx_proj_u = common::ProjectToWireView(

--- a/AnalysisTools/TrackAnalysis_tool.cc
+++ b/AnalysisTools/TrackAnalysis_tool.cc
@@ -217,11 +217,11 @@ void TrackAnalysis::analyseSlice(const art::Event& event, std::vector<common::Pr
             track_vertex -= neutrino_vertex;
             _track_distance_to_vertex.push_back(track_vertex.Mag());
 
-            _trk_llr_pid_u_v.push_back(std::numeric_limits<float>::lowest());
-            _trk_llr_pid_v_v.push_back(std::numeric_limits<float>::lowest());
-            _trk_llr_pid_y_v.push_back(std::numeric_limits<float>::lowest());
+            _trk_llr_pid_u_v.push_back(std::numeric_limits<float>::quiet_NaN());
+            _trk_llr_pid_v_v.push_back(std::numeric_limits<float>::quiet_NaN());
+            _trk_llr_pid_y_v.push_back(std::numeric_limits<float>::quiet_NaN());
             _trk_llr_pid_v.push_back(0.0f);
-            _trk_llr_pid_score_v.push_back(std::numeric_limits<float>::lowest());
+            _trk_llr_pid_score_v.push_back(std::numeric_limits<float>::quiet_NaN());
 
             auto calorimetry_objects = calorimetry_proxy[track.key()].get<anab::Calorimetry>();
             for (const auto& calo : calorimetry_objects) {
@@ -305,46 +305,46 @@ void TrackAnalysis::analyseSlice(const art::Event& event, std::vector<common::Pr
 
 void TrackAnalysis::fill_default() {
     _track_pfp_ids.push_back(std::numeric_limits<size_t>::max());
-    _track_start_x.push_back(std::numeric_limits<float>::lowest());
-    _track_start_y.push_back(std::numeric_limits<float>::lowest());
-    _track_start_z.push_back(std::numeric_limits<float>::lowest());
-    _track_sce_start_x.push_back(std::numeric_limits<float>::lowest());
-    _track_sce_start_y.push_back(std::numeric_limits<float>::lowest());
-    _track_sce_start_z.push_back(std::numeric_limits<float>::lowest());
-    _track_end_x.push_back(std::numeric_limits<float>::lowest());
-    _track_end_y.push_back(std::numeric_limits<float>::lowest());
-    _track_end_z.push_back(std::numeric_limits<float>::lowest());
-    _track_sce_end_x.push_back(std::numeric_limits<float>::lowest());
-    _track_sce_end_y.push_back(std::numeric_limits<float>::lowest());
-    _track_sce_end_z.push_back(std::numeric_limits<float>::lowest());
-    _track_direction_x.push_back(std::numeric_limits<float>::lowest());
-    _track_direction_y.push_back(std::numeric_limits<float>::lowest());
-    _track_direction_z.push_back(std::numeric_limits<float>::lowest());
-    _track_distance_to_vertex.push_back(std::numeric_limits<float>::lowest());
-    _track_theta.push_back(std::numeric_limits<float>::lowest());
-    _track_phi.push_back(std::numeric_limits<float>::lowest());
-    _track_length.push_back(std::numeric_limits<float>::lowest());
-    _track_calo_energy_u.push_back(std::numeric_limits<float>::lowest());
-    _track_calo_energy_v.push_back(std::numeric_limits<float>::lowest());
-    _track_calo_energy_y.push_back(std::numeric_limits<float>::lowest());
-    _track_trunk_dedx_u.push_back(std::numeric_limits<float>::lowest());
-    _track_trunk_dedx_v.push_back(std::numeric_limits<float>::lowest());
-    _track_trunk_dedx_y.push_back(std::numeric_limits<float>::lowest());
-    _track_trunk_rr_dedx_u.push_back(std::numeric_limits<float>::lowest());
-    _track_trunk_rr_dedx_v.push_back(std::numeric_limits<float>::lowest());
-    _track_trunk_rr_dedx_y.push_back(std::numeric_limits<float>::lowest());
+    _track_start_x.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_start_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_start_z.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_sce_start_x.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_sce_start_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_sce_start_z.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_end_x.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_end_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_end_z.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_sce_end_x.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_sce_end_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_sce_end_z.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_direction_x.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_direction_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_direction_z.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_distance_to_vertex.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_theta.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_phi.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_length.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_calo_energy_u.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_calo_energy_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_calo_energy_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_trunk_dedx_u.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_trunk_dedx_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_trunk_dedx_y.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_trunk_rr_dedx_u.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_trunk_rr_dedx_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_trunk_rr_dedx_y.push_back(std::numeric_limits<float>::quiet_NaN());
     _track_nhits_u.push_back(std::numeric_limits<int>::lowest());
     _track_nhits_v.push_back(std::numeric_limits<int>::lowest());
     _track_nhits_y.push_back(std::numeric_limits<int>::lowest());
-    _track_avg_deflection_mean.push_back(std::numeric_limits<float>::lowest());
-    _track_avg_deflection_stdev.push_back(std::numeric_limits<float>::lowest());
-    _track_avg_deflection_separation_mean.push_back(std::numeric_limits<float>::lowest());
+    _track_avg_deflection_mean.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_avg_deflection_stdev.push_back(std::numeric_limits<float>::quiet_NaN());
+    _track_avg_deflection_separation_mean.push_back(std::numeric_limits<float>::quiet_NaN());
     _track_end_spacepoints.push_back(std::numeric_limits<int>::lowest());
-    _trk_llr_pid_u_v.push_back(std::numeric_limits<float>::lowest());
-    _trk_llr_pid_v_v.push_back(std::numeric_limits<float>::lowest());
-    _trk_llr_pid_y_v.push_back(std::numeric_limits<float>::lowest());
-    _trk_llr_pid_v.push_back(std::numeric_limits<float>::lowest());
-    _trk_llr_pid_score_v.push_back(std::numeric_limits<float>::lowest());
+    _trk_llr_pid_u_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _trk_llr_pid_v_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _trk_llr_pid_y_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _trk_llr_pid_v.push_back(std::numeric_limits<float>::quiet_NaN());
+    _trk_llr_pid_score_v.push_back(std::numeric_limits<float>::quiet_NaN());
 }
 
 void TrackAnalysis::setBranches(TTree* tree) {
@@ -441,7 +441,7 @@ float TrackAnalysis::calculate_track_trunk_dedx_by_hits(const std::vector<float>
     int last_hit_index = static_cast<int>(hit_count - (hit_count / 3)) - 1;
 
     if (first_hit_index - last_hit_index < 5) {
-        return std::numeric_limits<float>::lowest();
+        return std::numeric_limits<float>::quiet_NaN();
     }
 
     std::vector<float> trunk_dedx_values;
@@ -482,11 +482,11 @@ float TrackAnalysis::calculate_track_trunk_dedx_by_range(const std::vector<float
     const float length_fraction = 1.0f / 3.0f;
 
     if (residual_range_values.size() <= hits_to_skip) {
-        return std::numeric_limits<float>::lowest();
+        return std::numeric_limits<float>::quiet_NaN();
     }
 
     std::vector<std::pair<float, unsigned int>> residual_range_indices;
-    float max_residual_range = std::numeric_limits<float>::lowest();
+    float max_residual_range = std::numeric_limits<float>::quiet_NaN();
     for (unsigned int i = 0; i < residual_range_values.size(); ++i) {
         max_residual_range = std::max(max_residual_range, residual_range_values[i]);
         residual_range_indices.emplace_back(residual_range_values[i], i);
@@ -503,7 +503,7 @@ float TrackAnalysis::calculate_track_trunk_dedx_by_range(const std::vector<float
     }
 
     if (dedx_at_start.empty()) {
-        return std::numeric_limits<float>::lowest();
+        return std::numeric_limits<float>::quiet_NaN();
     }
 
     std::sort(dedx_at_start.begin(), dedx_at_start.end());
@@ -526,7 +526,7 @@ float TrackAnalysis::calculate_track_trunk_dedx_by_range(const std::vector<float
         }
     }
 
-    return (truncated_hit_count == 0) ? std::numeric_limits<float>::lowest() 
+    return (truncated_hit_count == 0) ? std::numeric_limits<float>::quiet_NaN() 
                                    : truncated_total / static_cast<float>(truncated_hit_count);
 }
 
@@ -544,9 +544,9 @@ void TrackAnalysis::calculate_track_deflections(const art::Ptr<recob::Track>& tr
     }
 
     if (valid_points.size() < 3) {
-        mean_deflections.push_back(std::numeric_limits<float>::lowest());
-        stdev_deflections.push_back(std::numeric_limits<float>::lowest());
-        mean_separation.push_back(std::numeric_limits<float>::lowest());
+        mean_deflections.push_back(std::numeric_limits<float>::quiet_NaN());
+        stdev_deflections.push_back(std::numeric_limits<float>::quiet_NaN());
+        mean_separation.push_back(std::numeric_limits<float>::quiet_NaN());
         return;
     }
 

--- a/AnalysisTools/TruthAnalysis_tool.cc
+++ b/AnalysisTools/TruthAnalysis_tool.cc
@@ -368,33 +368,33 @@ void TruthAnalysis::resetTTree(TTree* tree) {
     _interaction_ccnc = std::numeric_limits<int>::lowest();
     _interaction_mode = std::numeric_limits<int>::lowest();
     _interaction_type = std::numeric_limits<int>::lowest();
-    _neutrino_energy = std::numeric_limits<float>::lowest();
-    _neutrino_theta = std::numeric_limits<float>::lowest();
-    _neutrino_pt = std::numeric_limits<float>::lowest();
+    _neutrino_energy = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_theta = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_pt = std::numeric_limits<float>::quiet_NaN();
     _target_nucleus_pdg = std::numeric_limits<int>::lowest();
     _hit_nucleon_pdg = std::numeric_limits<int>::lowest();
-    _kinematic_W = std::numeric_limits<float>::lowest();
-    _kinematic_X = std::numeric_limits<float>::lowest();
-    _kinematic_Y = std::numeric_limits<float>::lowest();
-    _kinematic_Q_squared = std::numeric_limits<float>::lowest();
-    _neutrino_momentum_x = std::numeric_limits<float>::lowest();
-    _neutrino_momentum_y = std::numeric_limits<float>::lowest();
-    _neutrino_momentum_z = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_x = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_y = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_z = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_wire_u = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_wire_v = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_wire_w = std::numeric_limits<float>::lowest();
-    _neutrino_vertex_time = std::numeric_limits<float>::lowest();
-    _neutrino_sce_vertex_x = std::numeric_limits<float>::lowest();
-    _neutrino_sce_vertex_y = std::numeric_limits<float>::lowest();
-    _neutrino_sce_vertex_z = std::numeric_limits<float>::lowest();
-    _lepton_energy = std::numeric_limits<float>::lowest();
-    _true_neutrino_momentum_x = std::numeric_limits<float>::lowest();
-    _true_neutrino_momentum_y = std::numeric_limits<float>::lowest();
-    _true_neutrino_momentum_z = std::numeric_limits<float>::lowest();
-    _flux_path_length = std::numeric_limits<float>::lowest();
+    _kinematic_W = std::numeric_limits<float>::quiet_NaN();
+    _kinematic_X = std::numeric_limits<float>::quiet_NaN();
+    _kinematic_Y = std::numeric_limits<float>::quiet_NaN();
+    _kinematic_Q_squared = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_momentum_x = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_momentum_y = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_momentum_z = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_x = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_y = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_z = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_wire_u = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_wire_v = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_wire_w = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_vertex_time = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_sce_vertex_x = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_sce_vertex_y = std::numeric_limits<float>::quiet_NaN();
+    _neutrino_sce_vertex_z = std::numeric_limits<float>::quiet_NaN();
+    _lepton_energy = std::numeric_limits<float>::quiet_NaN();
+    _true_neutrino_momentum_x = std::numeric_limits<float>::quiet_NaN();
+    _true_neutrino_momentum_y = std::numeric_limits<float>::quiet_NaN();
+    _true_neutrino_momentum_z = std::numeric_limits<float>::quiet_NaN();
+    _flux_path_length = std::numeric_limits<float>::quiet_NaN();
     _flux_parent_pdg = std::numeric_limits<int>::lowest();
     _flux_hadron_pdg = std::numeric_limits<int>::lowest();
     _flux_decay_mode = std::numeric_limits<int>::lowest();
@@ -706,8 +706,8 @@ void TruthAnalysis::analyseEvent(const art::Event& event, bool is_data) {
         _mc_end_vertex_x.push_back(mcp.EndX());
         _mc_end_vertex_y.push_back(mcp.EndY());
         _mc_end_vertex_z.push_back(mcp.EndZ());
-        _mc_completeness.push_back(std::numeric_limits<float>::lowest());
-        _mc_purity.push_back(std::numeric_limits<float>::lowest());
+        _mc_completeness.push_back(std::numeric_limits<float>::quiet_NaN());
+        _mc_purity.push_back(std::numeric_limits<float>::quiet_NaN());
 
         std::string final_state;
         if (mcp.NumberDaughters() > 0) {
@@ -823,8 +823,8 @@ void TruthAnalysis::CollectDescendants(const art::ValidHandle<std::vector<simb::
         }
         _mc_allchain_final_state.push_back(final_state);
 
-        _mc_allchain_completeness.push_back(std::numeric_limits<float>::lowest());
-        _mc_allchain_purity.push_back(std::numeric_limits<float>::lowest());
+        _mc_allchain_completeness.push_back(std::numeric_limits<float>::quiet_NaN());
+        _mc_allchain_purity.push_back(std::numeric_limits<float>::quiet_NaN());
 
         this->CollectDescendants(mcp_h, mcParticleMap, dau, primary_index);
     }


### PR DESCRIPTION
## Summary
- replace use of `std::numeric_limits<float>::lowest()` with `quiet_NaN()` across analysis tools
- update checks for unset values to use `std::isnan`
- add missing `<limits>` (and `<cmath>` where required)

## Testing
- `bash .test.sh run_neutrinoselection.fcl 1` *(fails: samweb: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc160deea4832e9137c982c0ed2552