### PR TITLE
Refactor image analysis into modular header-only utilities

### DIFF
--- a/Image.h
+++ b/Image.h
@@ -1,5 +1,5 @@
-#ifndef IMAGETYPES_H
-#define IMAGETYPES_H
+#ifndef IMAGE_H
+#define IMAGE_H
 
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -106,4 +106,4 @@ class Image {
 };
 } // namespace analysis
 
-#endif // IMAGETYPES_H
+#endif // IMAGE_H

--- a/ImageProducer.h
+++ b/ImageProducer.h
@@ -1,0 +1,255 @@
+#ifndef IMAGEPRODUCER_H
+#define IMAGEPRODUCER_H
+
+#include "Image.h"
+#include "SemanticPixelClassifier.h"
+
+#include "art/Framework/Principal/Event.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "lardataobj/RecoBase/Wire.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include <lardataobj/AnalysisBase/BackTrackerMatchingData.h>
+#include <TVector3.h>
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace analysis {
+class ImageProducer {
+  public:
+    static void constructPixelImages(const art::Event &event,
+                                     const std::vector<art::Ptr<recob::Hit>> &hits,
+                                     const std::vector<ImageProperties> &properties,
+                                     std::vector<Image<float>> &detector_images,
+                                     std::vector<Image<int>> &semantic_images,
+                                     bool is_data,
+                                     const art::InputTag &wireProducer,
+                                     const art::InputTag &hitProducer,
+                                     const art::InputTag &mcpProducer,
+                                     const art::InputTag &bktProducer,
+                                     const geo::GeometryCore *geo,
+                                     const detinfo::DetectorProperties *detp,
+                                     float adc_image_threshold,
+                                     SemanticPixelClassifier *semantic_classifier,
+                                     const std::set<unsigned int> &badChannels);
+
+  private:
+    static SemanticPixelClassifier::SemanticLabel labelSemanticPixels(
+        const art::Ptr<recob::Hit> &matched_hit,
+        const art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>
+            &mcp_bkth_assoc,
+        const art::Handle<std::vector<simb::MCParticle>> &mcp_vector,
+        const std::map<int, size_t> &trackid_to_index,
+        const std::vector<SemanticPixelClassifier::SemanticLabel>
+            &semantic_label_vector,
+        bool has_mcps);
+
+    static void fillDetectorImage(
+        const recob::Wire &wire, size_t wire_idx,
+        const std::vector<ImageProperties> &properties,
+        const art::FindManyP<recob::Hit> &wire_hit_assoc,
+        const std::set<art::Ptr<recob::Hit>> &hit_set,
+        const art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>
+            &mcp_bkth_assoc,
+        const art::Handle<std::vector<simb::MCParticle>> &mcp_vector,
+        const std::map<int, size_t> &trackid_to_index,
+        const std::vector<SemanticPixelClassifier::SemanticLabel>
+            &semantic_label_vector,
+        std::vector<Image<float>> &detector_images,
+        std::vector<Image<int>> &semantic_images,
+        bool is_data, bool has_mcps,
+        const geo::GeometryCore *geo,
+        const detinfo::DetectorProperties *detp,
+        float adc_image_threshold,
+        SemanticPixelClassifier *semantic_classifier,
+        const std::set<unsigned int> &badChannels);
+};
+
+inline SemanticPixelClassifier::SemanticLabel ImageProducer::labelSemanticPixels(
+    const art::Ptr<recob::Hit> &matched_hit,
+    const art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>
+        &mcp_bkth_assoc,
+    const art::Handle<std::vector<simb::MCParticle>> &mcp_vector,
+    const std::map<int, size_t> &trackid_to_index,
+    const std::vector<SemanticPixelClassifier::SemanticLabel>
+        &semantic_label_vector,
+    bool has_mcps) {
+    SemanticPixelClassifier::SemanticLabel semantic_pixel_label =
+        SemanticPixelClassifier::SemanticLabel::Cosmic;
+    if (!has_mcps || !mcp_vector.isValid())
+        return semantic_pixel_label;
+    std::vector<art::Ptr<simb::MCParticle>> mcp_particles_ass_to_hit;
+    std::vector<anab::BackTrackerHitMatchingData const *> bkth_data_ass_to_hit;
+    mcp_bkth_assoc.get(matched_hit.key(), mcp_particles_ass_to_hit,
+                       bkth_data_ass_to_hit);
+    if (!bkth_data_ass_to_hit.empty()) {
+        float max_ide_fraction = -1.0;
+        int best_match_track_id = -1;
+        for (size_t i_bkth = 0; i_bkth < bkth_data_ass_to_hit.size(); ++i_bkth) {
+            if (bkth_data_ass_to_hit[i_bkth] &&
+                bkth_data_ass_to_hit[i_bkth]->ideFraction > max_ide_fraction) {
+                max_ide_fraction = bkth_data_ass_to_hit[i_bkth]->ideFraction;
+                best_match_track_id =
+                    mcp_particles_ass_to_hit[i_bkth]->TrackId();
+            }
+        }
+        if (best_match_track_id != -1) {
+            auto it_trackid = trackid_to_index.find(best_match_track_id);
+            if (it_trackid != trackid_to_index.end()) {
+                size_t particle_mcp_idx = it_trackid->second;
+                if (particle_mcp_idx < semantic_label_vector.size()) {
+                    semantic_pixel_label =
+                        semantic_label_vector[particle_mcp_idx];
+                }
+            }
+        }
+    }
+    return semantic_pixel_label;
+}
+
+inline void ImageProducer::fillDetectorImage(
+    const recob::Wire &wire, size_t wire_idx,
+    const std::vector<ImageProperties> &properties,
+    const art::FindManyP<recob::Hit> &wire_hit_assoc,
+    const std::set<art::Ptr<recob::Hit>> &hit_set,
+    const art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>
+        &mcp_bkth_assoc,
+    const art::Handle<std::vector<simb::MCParticle>> &mcp_vector,
+    const std::map<int, size_t> &trackid_to_index,
+    const std::vector<SemanticPixelClassifier::SemanticLabel>
+        &semantic_label_vector,
+    std::vector<Image<float>> &detector_images,
+    std::vector<Image<int>> &semantic_images, bool is_data, bool has_mcps,
+    const geo::GeometryCore *geo, const detinfo::DetectorProperties *detp,
+    float adc_image_threshold, SemanticPixelClassifier *semantic_classifier,
+    const std::set<unsigned int> &badChannels) {
+    (void)semantic_classifier;
+    auto ch_id = wire.Channel();
+    if (badChannels.count(ch_id)) {
+        return;
+    }
+    std::vector<geo::WireID> wire_ids = geo->ChannelToWire(ch_id);
+    if (wire_ids.empty())
+        return;
+    geo::View_t view = geo->View(wire_ids.front().planeID());
+    size_t view_idx = static_cast<size_t>(view);
+    const geo::WireGeo *wire_geo = geo->WirePtr(wire_ids.front());
+    TVector3 center = wire_geo->GetCenter();
+    TVector3 wire_center(center.X(), center.Y(), center.Z());
+    double wire_coord =
+        (view == geo::kW)
+            ? wire_center.Z()
+        : (view == geo::kU)
+            ? (wire_center.Z() * std::cos(1.04719758034) -
+               wire_center.Y() * std::sin(1.04719758034))
+            : (wire_center.Z() * std::cos(-1.04719758034) -
+               wire_center.Y() * std::sin(-1.04719758034));
+    auto hits_for_wire = wire_hit_assoc.at(wire_idx);
+    std::vector<art::Ptr<recob::Hit>> filtered_hits;
+    for (const auto &hit : hits_for_wire) {
+        if (hit_set.count(hit)) {
+            filtered_hits.push_back(hit);
+        }
+    }
+    std::sort(filtered_hits.begin(), filtered_hits.end(),
+              [](const art::Ptr<recob::Hit> &a,
+                 const art::Ptr<recob::Hit> &b) {
+                  return a->StartTick() < b->StartTick();
+              });
+    size_t hit_index = 0;
+    for (const auto &range : wire.SignalROI().get_ranges()) {
+        const auto &adcs = range.data();
+        int start_tick = range.begin_index();
+        for (size_t adc_index = 0; adc_index < adcs.size(); ++adc_index) {
+            int tick = start_tick + adc_index;
+            double x_drift_pos =
+                detp->ConvertTicksToX(static_cast<double>(tick),
+                                      wire_ids.front().planeID());
+            size_t row = properties[view_idx].row(x_drift_pos);
+            size_t col = properties[view_idx].col(wire_coord);
+            if (row == static_cast<size_t>(-1) ||
+                col == static_cast<size_t>(-1))
+                continue;
+            while (hit_index < filtered_hits.size() &&
+                   filtered_hits[hit_index]->EndTick() <= tick) {
+                ++hit_index;
+            }
+            if (hit_index < filtered_hits.size() &&
+                filtered_hits[hit_index]->StartTick() <= tick &&
+                tick < filtered_hits[hit_index]->EndTick()) {
+                if (adcs[adc_index] > adc_image_threshold) {
+                    detector_images[view_idx].set(row, col, adcs[adc_index]);
+                    if (!is_data) {
+                        auto semantic_pixel_label = labelSemanticPixels(
+                            filtered_hits[hit_index], mcp_bkth_assoc, mcp_vector,
+                            trackid_to_index, semantic_label_vector, has_mcps);
+                        semantic_images[view_idx].set(
+                            row, col, static_cast<int>(semantic_pixel_label),
+                            false);
+                    }
+                }
+            }
+        }
+    }
+}
+
+inline void ImageProducer::constructPixelImages(
+    const art::Event &event, const std::vector<art::Ptr<recob::Hit>> &hits,
+    const std::vector<ImageProperties> &properties,
+    std::vector<Image<float>> &detector_images,
+    std::vector<Image<int>> &semantic_images, bool is_data,
+    const art::InputTag &wireProducer, const art::InputTag &hitProducer,
+    const art::InputTag &mcpProducer, const art::InputTag &bktProducer,
+    const geo::GeometryCore *geo, const detinfo::DetectorProperties *detp,
+    float adc_image_threshold, SemanticPixelClassifier *semantic_classifier,
+    const std::set<unsigned int> &badChannels) {
+    detector_images.clear();
+    semantic_images.clear();
+    for (const auto &prop : properties) {
+        Image<float> detector_image(prop);
+        detector_image.clear(0.0);
+        detector_images.push_back(std::move(detector_image));
+        Image<int> semantic_image(prop);
+        semantic_image.clear(
+            static_cast<int>(SemanticPixelClassifier::SemanticLabel::Empty));
+        semantic_images.push_back(std::move(semantic_image));
+    }
+    auto wire_vector =
+        event.getValidHandle<std::vector<recob::Wire>>(wireProducer);
+    auto hit_vector =
+        event.getValidHandle<std::vector<recob::Hit>>(hitProducer);
+    art::Handle<std::vector<simb::MCParticle>> mcp_vector;
+    bool has_mcps = event.getByLabel(mcpProducer, mcp_vector);
+    art::FindManyP<recob::Hit> wire_hit_assoc(wire_vector, event, hitProducer);
+    art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>
+        mcp_bkth_assoc(hit_vector, event, bktProducer);
+    std::vector<SemanticPixelClassifier::SemanticLabel> semantic_label_vector;
+    if (!is_data && has_mcps && mcp_vector.isValid() && semantic_classifier) {
+        semantic_label_vector = semantic_classifier->classifyParticles(event);
+    }
+    std::map<int, size_t> trackid_to_index;
+    if (!is_data && has_mcps && mcp_vector.isValid()) {
+        for (size_t i = 0; i < mcp_vector->size(); ++i) {
+            trackid_to_index[mcp_vector->at(i).TrackId()] = i;
+        }
+    }
+    std::set<art::Ptr<recob::Hit>> hit_set(hits.begin(), hits.end());
+    for (size_t wire_idx = 0; wire_idx < wire_vector->size(); ++wire_idx) {
+        fillDetectorImage(wire_vector->at(wire_idx), wire_idx, properties,
+                          wire_hit_assoc, hit_set, mcp_bkth_assoc, mcp_vector,
+                          trackid_to_index, semantic_label_vector,
+                          detector_images, semantic_images, is_data, has_mcps,
+                          geo, detp, adc_image_threshold, semantic_classifier,
+                          badChannels);
+    }
+}
+
+} // namespace analysis
+
+#endif // IMAGEPRODUCER_H

--- a/InferenceEngine.h
+++ b/InferenceEngine.h
@@ -1,0 +1,144 @@
+#ifndef INFERENCEENGINE_H
+#define INFERENCEENGINE_H
+
+#include "Image.h"
+#include "Common/NpyUtils.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <sys/stat.h>
+#include <cstdio>
+#include <cetlib_except/exception.h>
+#include "art/Utilities/Exception.h"
+#include <messagefacility/MessageLogger/MessageLogger.h>
+
+namespace analysis {
+class InferenceEngine {
+  public:
+    static float runInference(const std::vector<Image<float>> &detector_images,
+                              const std::string &absolute_scratch_dir,
+                              const std::string &work_dir,
+                              const std::string &arch,
+                              const std::string &weights_file,
+                              const std::string &inference_wrapper,
+                              const std::string &assets_base_dir);
+};
+
+inline std::string joinPath(std::string a, const std::string &b) {
+    if (a.empty()) return b;
+    if (!a.empty() && a.back() != '/') a.push_back('/');
+    return a + b;
+}
+
+inline float InferenceEngine::runInference(
+    const std::vector<Image<float>> &detector_images,
+    const std::string &absolute_scratch_dir, const std::string &work_dir,
+    const std::string &arch, const std::string &weights_file,
+    const std::string &inference_wrapper,
+    const std::string &assets_base_dir) {
+    using std::string;
+    (void)work_dir;
+    string npy_in = joinPath(absolute_scratch_dir, "detector_images.npy");
+    string temp_out = joinPath(absolute_scratch_dir, "temp_test_out.txt");
+    string script_stdout = joinPath(absolute_scratch_dir, "py_script.out");
+    string script_stderr = joinPath(absolute_scratch_dir, "py_script.err");
+
+    std::vector<std::vector<float>> images = {
+        detector_images[0].data(),
+        detector_images[1].data(),
+        detector_images[2].data()};
+    common::save_npy_f32_2d(npy_in, images);
+
+    string container = "/cvmfs/uboone.opensciencegrid.org/containers/lantern_v2_me_06_03_prod";
+
+    std::string assets_dir = assets_base_dir;
+    if (assets_dir.empty()) {
+        auto pos = inference_wrapper.rfind("/scripts/");
+        assets_dir = (pos == std::string::npos) ? std::string{} : inference_wrapper.substr(0, pos);
+    }
+
+    std::vector<std::string> binds;
+    if (!assets_dir.empty())
+        binds.push_back(assets_dir);
+    binds.push_back(absolute_scratch_dir);
+
+    bool need_cvmfs = true;
+    if (const char *bind_env = std::getenv("APPTAINER_BINDPATH")) {
+        if (std::string(bind_env).find("/cvmfs") != std::string::npos)
+            need_cvmfs = false;
+    } else {
+        std::ifstream mounts("/proc/mounts");
+        std::string line;
+        while (std::getline(mounts, line)) {
+            if (line.find(" /cvmfs ") != std::string::npos) {
+                need_cvmfs = false;
+                break;
+            }
+        }
+    }
+    if (need_cvmfs)
+        binds.insert(binds.begin(), "/cvmfs");
+
+    std::ostringstream bind_csv;
+    for (size_t i = 0; i < binds.size(); ++i) {
+        if (i)
+            bind_csv << ",";
+        bind_csv << binds[i];
+    }
+
+    std::ostringstream cmd;
+    cmd << "apptainer exec --cleanenv --bind " << bind_csv.str() << " "
+        << container << " "
+        << "/bin/bash " << inference_wrapper << " "
+        << "--npy " << npy_in << " "
+        << "--output " << temp_out << " "
+        << "--arch " << arch << " "
+        << "--weights " << weights_file
+        << " > " << script_stdout << " 2> " << script_stderr;
+
+    mf::LogInfo("InferenceEngine") << "Executing inference: " << cmd.str();
+
+    auto start = std::chrono::steady_clock::now();
+    int code = std::system(cmd.str().c_str());
+    auto end = std::chrono::steady_clock::now();
+    double duration = std::chrono::duration<double>(end - start).count();
+
+    struct stat temp_stat;
+    bool success = (code == 0) && (stat(temp_out.c_str(), &temp_stat) == 0);
+    if (!success) {
+        std::ifstream error_stream(script_stderr);
+        std::string error_message(
+            (std::istreambuf_iterator<char>(error_stream)), {});
+        throw art::Exception(art::errors::LogicError)
+            << "Inference script failed with exit code " << code
+            << "\n--- Script stderr ---\n"
+            << error_message << "\n--- End Script stderr ---";
+    }
+
+    std::ifstream result_stream(temp_out.c_str());
+    if (!result_stream) {
+        throw art::Exception(art::errors::LogicError)
+            << "Could not open temporary result file: " << temp_out;
+    }
+    float score;
+    result_stream >> score;
+
+    mf::LogInfo("InferenceEngine")
+        << "Inference time: " << duration << " seconds";
+    mf::LogInfo("InferenceEngine") << "Predicted score: " << score;
+
+    std::remove(npy_in.c_str());
+    std::remove(temp_out.c_str());
+    std::remove(script_stdout.c_str());
+    std::remove(script_stderr.c_str());
+
+    return score;
+}
+
+} // namespace analysis
+
+#endif // INFERENCEENGINE_H

--- a/SemanticPixelClassifier.h
+++ b/SemanticPixelClassifier.h
@@ -1,5 +1,5 @@
-#ifndef TRUTHLABELCLASSIFIER_H
-#define TRUTHLABELCLASSIFIER_H
+#ifndef SEMANTICPIXELCLASSIFIER_H
+#define SEMANTICPIXELCLASSIFIER_H
 
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Optional/TFileService.h"
@@ -27,7 +27,7 @@
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include <lardataobj/AnalysisBase/BackTrackerMatchingData.h>
 
-#include "ImageTypes.h"
+#include "Image.h"
 #include "PandoraUtilities.h"
 #include <TDirectoryFile.h>
 #include <TFile.h>
@@ -46,9 +46,9 @@
 #include <vector>
 
 namespace analysis {
-class TruthLabelClassifier {
+class SemanticPixelClassifier {
     public:
-    enum class TruthPrimaryLabel {
+    enum class SemanticLabel {
         Empty = 0,
         Cosmic,
         Muon,
@@ -66,51 +66,51 @@ class TruthLabelClassifier {
         Other
     };
 
-    static inline const std::array<std::string, 15> truth_primary_label_names = {
+    static inline const std::array<std::string, 15> semantic_label_names = {
         "Empty", "Cosmic", "Muon", "Electron", "Photon",
         "ChargedPion", "NeutralPion", "Neutron", "Proton",
         "ChargedKaon", "NeutralKaon", "Lambda", "ChargedSigma",
         "NeutralSigma", "Other"};
 
-    explicit TruthLabelClassifier(const art::InputTag &MCPproducer)
+    explicit SemanticPixelClassifier(const art::InputTag &MCPproducer)
         : fMCPproducer(MCPproducer) {}
 
-    TruthPrimaryLabel getTruthPrimaryLabel(int pdg) const {
+    SemanticLabel getSemanticLabel(int pdg) const {
         pdg = std::abs(pdg);
         if (pdg == 13)
-            return TruthPrimaryLabel::Muon;
+            return SemanticLabel::Muon;
         if (pdg == 11)
-            return TruthPrimaryLabel::Electron;
+            return SemanticLabel::Electron;
         if (pdg == 22)
-            return TruthPrimaryLabel::Photon;
+            return SemanticLabel::Photon;
         if (pdg == 2112)
-            return TruthPrimaryLabel::Neutron;
+            return SemanticLabel::Neutron;
         if (pdg == 211)
-            return TruthPrimaryLabel::ChargedPion;
+            return SemanticLabel::ChargedPion;
         if (pdg == 111)
-            return TruthPrimaryLabel::NeutralPion;
+            return SemanticLabel::NeutralPion;
         if (pdg == 321)
-            return TruthPrimaryLabel::ChargedKaon;
+            return SemanticLabel::ChargedKaon;
         if (pdg == 311 || pdg == 130 || pdg == 310)
-            return TruthPrimaryLabel::NeutralKaon;
+            return SemanticLabel::NeutralKaon;
         if (pdg == 2212)
-            return TruthPrimaryLabel::Proton;
+            return SemanticLabel::Proton;
         if (pdg == 3122)
-            return TruthPrimaryLabel::Lambda;
+            return SemanticLabel::Lambda;
         if (pdg == 3222 || pdg == 3112)
-            return TruthPrimaryLabel::ChargedSigma;
+            return SemanticLabel::ChargedSigma;
         if (pdg == 3212)
-            return TruthPrimaryLabel::NeutralSigma;
+            return SemanticLabel::NeutralSigma;
 
-        return TruthPrimaryLabel::Other;
+        return SemanticLabel::Other;
     }
 
     void assignLabelToProgenyRecursively(
         size_t particle_index,
         const std::vector<simb::MCParticle> &particles,
-        std::vector<TruthPrimaryLabel> &particle_labels,
+        std::vector<SemanticLabel> &particle_labels,
         const std::unordered_map<int, size_t> &track_id_to_index,
-        TruthPrimaryLabel primary_label_to_assign) const {
+        SemanticLabel primary_label_to_assign) const {
         if (particle_index >= particles.size() || particle_index >= particle_labels.size()) {
             return;
         }
@@ -128,7 +128,7 @@ class TruthLabelClassifier {
         }
     }
 
-    std::vector<TruthPrimaryLabel> classifyParticles(
+    std::vector<SemanticLabel> classifyParticles(
         const art::Event &event) const {
         const auto particle_collection_handle = event.getValidHandle<std::vector<simb::MCParticle>>(fMCPproducer);
         const auto &particles = *particle_collection_handle;
@@ -138,12 +138,12 @@ class TruthLabelClassifier {
             track_id_to_vector_index[particles[i].TrackId()] = i;
         }
 
-        std::vector<TruthPrimaryLabel> classified_particle_labels(particles.size(), TruthPrimaryLabel::Empty);
+        std::vector<SemanticLabel> classified_particle_labels(particles.size(), SemanticLabel::Empty);
 
         for (size_t i = 0; i < particles.size(); ++i) {
             if (particles[i].Mother() == 0) {
                 if (auto it = track_id_to_vector_index.find(particles[i].TrackId()); it != track_id_to_vector_index.end()) {
-                    TruthPrimaryLabel initial_label = getTruthPrimaryLabel(particles[i].PdgCode());
+                    SemanticLabel initial_label = getSemanticLabel(particles[i].PdgCode());
                     assignLabelToProgenyRecursively(it->second, particles, classified_particle_labels, track_id_to_vector_index, initial_label);
                 }
             }
@@ -156,5 +156,5 @@ class TruthLabelClassifier {
 };
 } // namespace analysis
 
-#endif // TRUTHLABELCLASSIFIER_H
+#endif // SEMANTICPIXELCLASSIFIER_H
 


### PR DESCRIPTION
## Summary
- Relocate image and semantic classification headers to project root
- Introduce ImageProducer and InferenceEngine header-only utilities
- Update ImageAnalysis tool to use new modules and renamed SemanticPixelClassifier

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc1d989050832e8c0bdf38a40ea9c5