### PR TITLE
Fix include path for PandoraUtilities

### DIFF
--- a/SemanticPixelClassifier.h
+++ b/SemanticPixelClassifier.h
@@ -28,7 +28,7 @@
 #include <lardataobj/AnalysisBase/BackTrackerMatchingData.h>
 
 #include "Image.h"
-#include "PandoraUtilities.h"
+#include "Common/PandoraUtilities.h"
 #include <TDirectoryFile.h>
 #include <TFile.h>
 #include <TTree.h>


### PR DESCRIPTION
## Summary
- correct PandoraUtilities include in SemanticPixelClassifier

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `cmake ..` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc20a008b0832ebcecf0f56bc11af7