### PR TITLE
Use canvas Exception header path in InferenceEngine

### DIFF
--- a/InferenceEngine.h
+++ b/InferenceEngine.h
@@ -13,7 +13,7 @@
 #include <sys/stat.h>
 #include <cstdio>
 #include <cetlib_except/exception.h>
-#include "art/Utilities/Exception.h"
+#include <canvas/Utilities/Exception.h>
 #include <messagefacility/MessageLogger/MessageLogger.h>
 
 namespace analysis {


### PR DESCRIPTION
## Summary
- replace `art/Utilities/Exception.h` with `canvas/Utilities/Exception.h` to match available headers

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command `install_headers`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc21bd41c4832eb6fdd05e684ab7ef