### PR TITLE
Remove duplicate joinPath helper to resolve ambiguous overload

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -76,11 +76,6 @@ inline bool dirExists(const std::string &p) {
     struct stat sb;
     return ::stat(p.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode);
 }
-inline std::string joinPath(std::string a, const std::string &b) {
-    if (a.empty()) return b;
-    if (!a.empty() && a.back() != '/') a.push_back('/');
-    return a + b;
-}
 inline bool isAbs(const std::string &p) {
     return !p.empty() && p.front() == '/';
 }


### PR DESCRIPTION
## Summary
- Remove local `joinPath` implementation in ImageAnalysis to avoid conflict with `InferenceEngine`'s helper

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc22d420a4832e892f37ea31f5a9e1