### PR TITLE
Remove composite scores from VertexTopology analysis

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -38,8 +38,7 @@ private:
                             const std::vector<float>& weights,
                             const TVector3& beam_dir,
                             float& back_frac,
-                            float& off_frac,
-                            float& score);
+                            float& off_frac);
 
     TVector3 fBNBdir;
     TVector3 fNuMIdir;
@@ -51,11 +50,8 @@ private:
     float fBackMargin;
     float fBackQmax;
     float fVtxQmax;
-    float fAlpha;
-    float fBeta;
 
-    float _vtx_score_bnb;
-    float _vtx_score_numi;
+    // Composite vertex score parameters removed; only primitives retained
     float _vtx_backfrac_bnb;
     float _vtx_backfrac_numi;
     float _vtx_offfrac_bnb;
@@ -65,11 +61,7 @@ private:
     // Config
     float fKernelR;       // cm, soft radial kernel scale
     float fRhoRef;        // reference density for normalization
-    float fMuParTarget;   // target <|cosθ|> before penalizing (≈0.4)
-    float fFwdLambda;     // penalty strength (≈0.2)
-    float fWThrust;       // weight for thrust deficit (≈0.35)
-    float fWSpher;        // weight for sphericity (≈0.35)
-    float fWRho;          // weight for density term (≈0.30)
+    // Composite score parameters removed; downstream tuning expected
     int   fThrustIters;   // iterations for thrust maximization
 
     // Outputs (beam-independent primitives)
@@ -77,22 +69,15 @@ private:
     float _had_sphericity;    // sphericity
     float _had_rho_term;      // normalized local activity
 
-    // Beam-dependent pieces and final scores
+    // Beam-dependent primitives
     float _had_mu_parallel_bnb;
     float _had_mu_parallel_numi;
-    float _had_fwd_penalty_bnb;
-    float _had_fwd_penalty_numi;
-    float _hadflow_bnb;
-    float _hadflow_numi;
 
 private:
-    // HadFlow core
-    void compute_hadflow(const std::vector<TVector3>& u,
-                         const std::vector<float>& wtilde,
-                         const TVector3& beam_dir,
-                         float& mu_parallel,
-                         float& fwd_penalty,
-                         float& score) const;
+    // HadFlow core (only primitive, no composite score)
+    float compute_mu_parallel(const std::vector<TVector3>& u,
+                              const std::vector<float>& wtilde,
+                              const TVector3& beam_dir) const;
 
     // Helpers
     inline float kernel(float r) const {
@@ -134,17 +119,10 @@ void VertexTopology::configure(fhicl::ParameterSet const &pset)
     fBackMargin = pset.get<float>("BackwardCosMargin", 0.05f);
     fBackQmax = pset.get<float>("BackwardMax", std::numeric_limits<float>::max());
     fVtxQmax = pset.get<float>("VertexResidualMax", std::numeric_limits<float>::max());
-    fAlpha = pset.get<float>("Alpha", 1.f);
-    fBeta  = pset.get<float>("Beta",  1.f);
 
-    // --- HadFlow+ defaults ---
+    // --- HadFlow+ defaults (primitives only) ---
     fKernelR     = pset.get<float>("KernelR",        25.f);   // cm
     fRhoRef      = pset.get<float>("RhoRef",         50.f);   // tune on sidebands
-    fMuParTarget = pset.get<float>("MuParTarget",     0.4f);  // ⟨|cosθ|⟩ target
-    fFwdLambda   = pset.get<float>("FwdLambda",       0.2f);  // penalty strength
-    fWThrust     = pset.get<float>("WThrust",         0.35f);
-    fWSpher      = pset.get<float>("WSpher",          0.35f);
-    fWRho        = pset.get<float>("WRho",            0.30f);
     fThrustIters = pset.get<int>("ThrustIters",       6);
 }
 
@@ -191,9 +169,9 @@ void VertexTopology::analyseSlice(const art::Event &,
 
     // --- Original vertex-cleanness summaries (BNB / NuMI) ---
     compute_vtx_scores(dirs, weights, fBNBdir,
-                       _vtx_backfrac_bnb, _vtx_offfrac_bnb, _vtx_score_bnb);
+                       _vtx_backfrac_bnb, _vtx_offfrac_bnb);
     compute_vtx_scores(dirs, weights, fNuMIdir,
-                       _vtx_backfrac_numi, _vtx_offfrac_numi, _vtx_score_numi);
+                       _vtx_backfrac_numi, _vtx_offfrac_numi);
 
     // --- HadFlow+ primitives (make unit directions + kernel-weighted weights) ---
     std::vector<TVector3> u;        u.reserve(dirs.size());
@@ -215,10 +193,6 @@ void VertexTopology::analyseSlice(const art::Event &,
 
         _had_mu_parallel_bnb  = 0.f;
         _had_mu_parallel_numi = 0.f;
-        _had_fwd_penalty_bnb  = 0.f;
-        _had_fwd_penalty_numi = 0.f;
-        _hadflow_bnb = 0.f;
-        _hadflow_numi = 0.f;
         return;
     }
 
@@ -226,11 +200,9 @@ void VertexTopology::analyseSlice(const art::Event &,
     _had_sphericity = sphericity(u, wtilde);
     _had_rho_term   = rho_term(wtilde);
 
-    // Beam-aware HadFlow scores
-    compute_hadflow(u, wtilde, fBNBdir,
-                    _had_mu_parallel_bnb, _had_fwd_penalty_bnb, _hadflow_bnb);
-    compute_hadflow(u, wtilde, fNuMIdir,
-                    _had_mu_parallel_numi, _had_fwd_penalty_numi, _hadflow_numi);
+    // Beam-aware HadFlow primitive
+    _had_mu_parallel_bnb  = compute_mu_parallel(u, wtilde, fBNBdir);
+    _had_mu_parallel_numi = compute_mu_parallel(u, wtilde, fNuMIdir);
 }
 
 // ---------- Original vertex-cleanness computation ----------
@@ -238,8 +210,7 @@ void VertexTopology::compute_vtx_scores(const std::vector<TVector3>& dirs,
                                         const std::vector<float>& weights,
                                         const TVector3& beam_dir,
                                         float& back_frac,
-                                        float& off_frac,
-                                        float& score)
+                                        float& off_frac)
 {
     float sum_ann = 0.f, sum_back = 0.f;
     float sum_vtx = 0.f, sum_vtx_off = 0.f;
@@ -267,8 +238,6 @@ void VertexTopology::compute_vtx_scores(const std::vector<TVector3>& dirs,
 
     off_frac = (sum_vtx > 0) ? sum_vtx_off / sum_vtx : 0.f;
     if (sum_vtx_off > fVtxQmax) off_frac = 1.f;
-
-    score = fAlpha * back_frac + fBeta * off_frac;
 }
 
 // ---------- HadFlow helpers ----------
@@ -334,74 +303,47 @@ float VertexTopology::rho_term(const std::vector<float>& w) const
     return static_cast<float>(clamp01(term));
 }
 
-void VertexTopology::compute_hadflow(const std::vector<TVector3>& u,
-                                     const std::vector<float>& wtilde,
-                                     const TVector3& beam_dir,
-                                     float& mu_parallel,
-                                     float& fwd_penalty,
-                                     float& score) const
+float VertexTopology::compute_mu_parallel(const std::vector<TVector3>& u,
+                                          const std::vector<float>& wtilde,
+                                          const TVector3& beam_dir) const
 {
-    if (wtilde.empty()) {
-        mu_parallel = fwd_penalty = score = 0.f;
-        return;
-    }
+    if (wtilde.empty()) return 0.f;
     double sumW = 0.0, sumWabs = 0.0;
     for (size_t i = 0; i < u.size(); ++i) {
         const double wi = wtilde[i];
         sumW += wi;
         sumWabs += wi * std::abs(u[i].Dot(beam_dir));
     }
-    mu_parallel = (sumW > 0.0) ? static_cast<float>(sumWabs / sumW) : 0.f;
-
-    const float P = std::max(0.f, mu_parallel - fMuParTarget);
-    fwd_penalty = P;
-
-    const float raw =
-        fWThrust * _had_thrust_def +
-        fWSpher  * _had_sphericity +
-        fWRho    * _had_rho_term -
-        fFwdLambda * fwd_penalty;
-
-    score = clamp01(raw);
+    return (sumW > 0.0) ? static_cast<float>(sumWabs / sumW) : 0.f;
 }
 
 // ---------- I/O ----------
 void VertexTopology::setBranches(TTree *t)
 {
     // Original cleanness (kept for compatibility)
-    t->Branch("vtx_score_bnb",     &_vtx_score_bnb,     "vtx_score_bnb/F");
-    t->Branch("vtx_score_numi",    &_vtx_score_numi,    "vtx_score_numi/F");
     t->Branch("vtx_backfrac_bnb",  &_vtx_backfrac_bnb,  "vtx_backfrac_bnb/F");
     t->Branch("vtx_backfrac_numi", &_vtx_backfrac_numi, "vtx_backfrac_numi/F");
     t->Branch("vtx_offfrac_bnb",   &_vtx_offfrac_bnb,   "vtx_offfrac_bnb/F");
     t->Branch("vtx_offfrac_numi",  &_vtx_offfrac_numi,  "vtx_offfrac_numi/F");
 
-    // HadFlow+ primitives and scores
+    // HadFlow+ primitives
     t->Branch("had_thrust_def",      &_had_thrust_def,      "had_thrust_def/F");
     t->Branch("had_sphericity",      &_had_sphericity,      "had_sphericity/F");
     t->Branch("had_rho_term",        &_had_rho_term,        "had_rho_term/F");
 
     t->Branch("had_mu_parallel_bnb", &_had_mu_parallel_bnb, "had_mu_parallel_bnb/F");
     t->Branch("had_mu_parallel_numi",&_had_mu_parallel_numi,"had_mu_parallel_numi/F");
-    t->Branch("had_fwd_penalty_bnb", &_had_fwd_penalty_bnb, "had_fwd_penalty_bnb/F");
-    t->Branch("had_fwd_penalty_numi",&_had_fwd_penalty_numi,"had_fwd_penalty_numi/F");
-
-    t->Branch("hadflow_bnb",         &_hadflow_bnb,         "hadflow_bnb/F");
-    t->Branch("hadflow_numi",        &_hadflow_numi,        "hadflow_numi/F");
 }
 
 void VertexTopology::resetTTree(TTree *)
 {
     const float NaN = std::numeric_limits<float>::quiet_NaN();
 
-    _vtx_score_bnb = NaN;   _vtx_score_numi = NaN;
     _vtx_backfrac_bnb = NaN; _vtx_backfrac_numi = NaN;
     _vtx_offfrac_bnb = NaN;  _vtx_offfrac_numi = NaN;
 
     _had_thrust_def = NaN; _had_sphericity = NaN; _had_rho_term = NaN;
     _had_mu_parallel_bnb = NaN; _had_mu_parallel_numi = NaN;
-    _had_fwd_penalty_bnb = NaN; _had_fwd_penalty_numi = NaN;
-    _hadflow_bnb = NaN; _hadflow_numi = NaN;
 }
 
 DEFINE_ART_CLASS_TOOL(VertexTopology)


### PR DESCRIPTION
## Summary
- avoid computing composite vertex scores in `VertexTopology`
- keep only primitive metrics and introduce `compute_mu_parallel`

## Testing
- `cmake .` *(fails: Unknown CMake command "install_headers")*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3b6d16d0832ea41ad052db0ea3f6