### PR TITLE
Use dynamic spacepoint reserve

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -211,7 +211,10 @@ void VertexTopology::analyseSlice(const art::Event &event,
     // --- Gather displacement vectors and weights (sum charge of associated hits) ---
     std::vector<TVector3> dirs;
     std::vector<float>    weights;
-    dirs.reserve(1024); weights.reserve(1024);
+    // Reserve enough space for all space points in the event
+    size_t nspacepoints = sp_h->size();
+    dirs.reserve(nspacepoints);
+    weights.reserve(nspacepoints);
 
     for (auto const &pfp : slice_pfp_vec) {
         int pdg = std::abs(pfp->PdgCode());


### PR DESCRIPTION
## Summary
- Reserve spacepoint direction and weight vectors based on actual spacepoint count

## Testing
- `./.build.sh` (fails: mrbsetenv: command not found)
- `bash .test.sh run_neutrinoselection.fcl 1` (fails: samweb: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc3f319a14832e9abe050666ff81b3