### PR TITLE
Use SpacePointproducer tag for spacepoint associations

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -203,7 +203,7 @@ void VertexTopology::analyseSlice(const art::Event &event,
 
     // --- Get PFParticle -> SpacePoint associations and SpacePoint -> Hit ---
     auto const &pfp_h = event.getValidHandle<std::vector<recob::PFParticle>>(fPFPproducer);
-    art::FindManyP<recob::SpacePoint> pfp_spacepoint_assn(pfp_h, event, fPFPproducer);
+    art::FindManyP<recob::SpacePoint> pfp_spacepoint_assn(pfp_h, event, fSpacePointproducer);
 
     auto const &sp_h = event.getValidHandle<std::vector<recob::SpacePoint>>(fSpacePointproducer);
     art::FindManyP<recob::Hit> sp_hit_assn(sp_h, event, fSpacePointproducer);


### PR DESCRIPTION
## Summary
- Use `SpacePointproducer` tag when building PFParticle to SpacePoint associations in `VertexTopology`

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*


------
https://chatgpt.com/codex/tasks/task_e_68bc3f175690832e9c84340a35bdd056