### PR TITLE
Clarify vertex fraction helper name

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -41,11 +41,11 @@ private:
     art::InputTag fPFPproducer;
     art::InputTag fSpacePointproducer;
     // ---------- Original "VertexCleanness" metrics ----------
-    void compute_vtx_scores(const std::vector<TVector3>& dirs,
-                            const std::vector<float>& weights,
-                            const TVector3& beam_dir,
-                            float& back_frac,
-                            float& off_frac);
+    void compute_back_off_fractions(const std::vector<TVector3>& dirs,
+                                    const std::vector<float>& weights,
+                                    const TVector3& beam_dir,
+                                    float& back_frac,
+                                    float& off_frac);
 
     TVector3 fBNBdir;
     TVector3 fNuMIdir;
@@ -235,10 +235,10 @@ void VertexTopology::analyseSlice(const art::Event &event,
     }
 
     // --- Original vertex-cleanness summaries (BNB / NuMI) ---
-    compute_vtx_scores(dirs, weights, fBNBdir,
-                       _vtx_backfrac_bnb, _vtx_offfrac_bnb);
-    compute_vtx_scores(dirs, weights, fNuMIdir,
-                       _vtx_backfrac_numi, _vtx_offfrac_numi);
+    compute_back_off_fractions(dirs, weights, fBNBdir,
+                               _vtx_backfrac_bnb, _vtx_offfrac_bnb);
+    compute_back_off_fractions(dirs, weights, fNuMIdir,
+                               _vtx_backfrac_numi, _vtx_offfrac_numi);
 
     // --- HadFlow+ primitives (make unit directions + kernel-weighted weights) ---
     std::vector<TVector3> u;        u.reserve(dirs.size());
@@ -273,11 +273,11 @@ void VertexTopology::analyseSlice(const art::Event &event,
 }
 
 // ---------- Original vertex-cleanness computation ----------
-void VertexTopology::compute_vtx_scores(const std::vector<TVector3>& dirs,
-                                        const std::vector<float>& weights,
-                                        const TVector3& beam_dir,
-                                        float& back_frac,
-                                        float& off_frac)
+void VertexTopology::compute_back_off_fractions(const std::vector<TVector3>& dirs,
+                                                const std::vector<float>& weights,
+                                                const TVector3& beam_dir,
+                                                float& back_frac,
+                                                float& off_frac)
 {
     float sum_ann = 0.f, sum_back = 0.f;
     float sum_vtx = 0.f, sum_vtx_off = 0.f;


### PR DESCRIPTION
## Summary
- rename `compute_vtx_scores` to `compute_back_off_fractions` for precision
- update usage and definition accordingly

## Testing
- `cmake -S . -B build` (fails: Unknown CMake command "install_headers")

------
https://chatgpt.com/codex/tasks/task_e_68bc3fb17a30832e889bb045d6d2b3e3