### PR TITLE
Use zero weight for spacepoints without hits

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -177,14 +177,11 @@ void VertexTopology::analyseSlice(
             if (r.Mag() < 1e-6)
                 continue;
 
-            float weight = 1.f;
+            float weight = 0.f;
             const std::vector<art::Ptr<recob::Hit>> &hits =
                 sp_hit_assn.at(sp.key());
-            if (!hits.empty()) {
-                weight = 0.f;
-                for (auto const &h : hits)
-                    weight += h->Integral();
-            }
+            for (auto const &h : hits)
+                weight += h->Integral();
 
             dirs.push_back(r);
             weights.push_back(weight);


### PR DESCRIPTION
## Summary
- Weight spacepoints by sum of hit integrals
- Default to zero weight when spacepoints lack associated hits

## Testing
- `bash .test.sh run_neutrinoselection.fcl 1` *(fails: samweb: command not found)*
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc44e77ca8832ebb2764bf310f0392