### PR TITLE
Expose VertexTopology interface publicly

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -23,7 +23,7 @@
 namespace analysis {
 
 class VertexTopology : public AnalysisToolBase {
-  private:
+  public:
     explicit VertexTopology(const fhicl::ParameterSet &pset);
     ~VertexTopology() {};
 
@@ -35,6 +35,7 @@ class VertexTopology : public AnalysisToolBase {
     void setBranches(TTree *tree) override;
     void resetTTree(TTree *tree) override;
 
+  private:
     art::InputTag fPFPproducer;
     art::InputTag fSpacePointproducer;
     void compute_back_off_fractions(const std::vector<TVector3> &dirs,


### PR DESCRIPTION
## Summary
- Make VertexTopology's constructor and core virtual methods public so the tool can be instantiated and configured externally

## Testing
- `cmake ..` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc461626e4832e94a9d8fd4cb8ae76