### PR TITLE
Add VertexTopology analysis tool configuration

### DIFF
--- a/job/selectionconfig.fcl
+++ b/job/selectionconfig.fcl
@@ -150,8 +150,9 @@ TruthAnalysis: {
     CLSproducer: @local::standard_producers.CLSproducer
 }
 
-InferenceTest: {
-    tool_type: "InferenceTest"
+VertexTopology: {
+    tool_type: "VertexTopology"
+    PFPproducer: @local::standard_producers.PFPproducer
 }
 
 EventSelectionFilter: {
@@ -193,5 +194,6 @@ NeutrinoSelectionFilter: {
         slice: @local::SliceAnalysis
         track: @local::TrackAnalysis
         truth: @local::TruthAnalysis
+        vertex: @local::VertexTopology
     }
 }


### PR DESCRIPTION
## Summary
- Add `VertexTopology` tool configuration for use in selection
- Remove unused `InferenceTest` block
- Centralize `VertexTopology` call in `NeutrinoSelectionFilter` table

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*


------
https://chatgpt.com/codex/tasks/task_e_68bc4f3bcbec832e85c931f8e73f1b6c