### PR TITLE
Fix typo in VertexTopology space point handle

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -166,7 +166,7 @@ void VertexTopology::analyseSlice(const art::Event &event, std::vector<common::P
     art::FindManyP<recob::SpacePoint> pfp_spacepoint_assn(pfp_h, event, fSPproducer);
 
     auto const &sp_h =
-        event.getValidHandle<std::vector<recob::SpacePoint>>(fSpacePointproducer);
+        event.getValidHandle<std::vector<recob::SpacePoint>>(fSPproducer);
     art::FindManyP<recob::Hit> sp_hit_assn(sp_h, event, fSPproducer);
 
     std::vector<TVector3> dirs;


### PR DESCRIPTION
## Summary
- Correct vertex topology tool to use configured space point producer handle

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68bc50f6af7c832ea629716b2bc5ab35