### PR TITLE
Fix SpacePoint position retrieval

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -181,8 +181,7 @@ void VertexTopology::analyseSlice(const art::Event &event, std::vector<common::P
         if (pdg == 12 || pdg == 14) continue;
         const std::vector<art::Ptr<recob::SpacePoint>> &sp_v = pfp_spacepoint_assn.at(pfp.index());
         for (auto const &sp : sp_v) {
-            double xyz[3];
-            sp->XYZ(xyz);
+            const auto xyz = sp->XYZ();
             TVector3 r(xyz[0] - vtx.X(), xyz[1] - vtx.Y(), xyz[2] - vtx.Z());
             if (r.Mag() < 1e-6) continue;
             float weight = 0.f;
@@ -369,7 +368,10 @@ float VertexTopology::fwd_contrast(const std::vector<TVector3> &dirs,
     const double base = (cf<=1.0 && cf>=-1.0) ? (1.0 - cf)/2.0 : 0.0;
     double cval = (denom>0.0) ? (Win/denom) : 0.0;
     if (base < 1.0) cval = (cval - base) / (1.0 - base);
-    if (cval < 0.0) cval = 0.0; if (cval > 1.0) cval = 1.0;
+    if (cval < 0.0)
+        cval = 0.0;
+    else if (cval > 1.0)
+        cval = 1.0;
     return static_cast<float>(cval);
 }
 


### PR DESCRIPTION
## Summary
- fix compilation error when retrieving `recob::SpacePoint` coordinates
- clean up forward contrast clamping logic

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `g++ -std=c++17 -c AnalysisTools/VertexTopology_tool.cc -I.` *(fails: art/Framework/Principal/Event.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc52d0de5c832e8a2ce3e42f134931