### PR TITLE
Allow backward margin in degrees

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -132,11 +132,12 @@ void VertexTopology::configure(fhicl::ParameterSet const &pset) {
     if (numi.size() == 3) fNuMIdir = TVector3(numi[0], numi[1], numi[2]).Unit();
     
     fVtxRadius = pset.get<float>("VertexRadius", 5.f);
-    float theta = pset.get<float>("ForwardAngleDeg", 30.f);
-    fFwdCos = std::cos(theta * TMath::DegToRad());
+    float fwd_angle = pset.get<float>("ForwardAngleDeg", 30.f);
+    fFwdCos = std::cos(fwd_angle * TMath::DegToRad());
     fBackRMin = pset.get<float>("BackwardRadiusMin", 3.f);
     fBackRMax = pset.get<float>("BackwardRadiusMax", 10.f);
-    fBackMargin = pset.get<float>("BackwardCosMargin", 0.08f);
+    float back_margin = pset.get<float>("BackwardAngleDeg", 10.f);
+    fBackMargin = std::sin(back_margin * TMath::DegToRad());
     fKernelR = pset.get<float>("KernelR", 25.f);
     fThrustIters = pset.get<int>("ThrustIters", 6);
     fContrastRc = pset.get<float>("ContrastRc", 5.f);

--- a/job/selectionconfig.fcl
+++ b/job/selectionconfig.fcl
@@ -153,6 +153,7 @@ TruthAnalysis: {
 VertexTopology: {
     tool_type: "VertexTopology"
     PFPproducer: @local::standard_producers.PFPproducer
+    BackwardAngleDeg: 10
 }
 
 EventSelectionFilter: {


### PR DESCRIPTION
## Summary
- Allow VertexTopology to configure backward/forward separation using a margin specified in degrees and defaulting to 10°.
- Demonstrate new parameter in `selectionconfig.fcl`.

## Testing
- `cmake ..` *(fails: Unknown CMake command "install_headers")*


------
https://chatgpt.com/codex/tasks/task_e_68bc5a35beb8832eb6da2e1401e1ae98