### PR TITLE
Fix unclosed analyseEvent function

### DIFF
--- a/AnalysisTools/VertexTopology_tool.cc
+++ b/AnalysisTools/VertexTopology_tool.cc
@@ -145,7 +145,9 @@ void VertexTopology::configure(fhicl::ParameterSet const &pset) {
     fContrastRb = pset.get<float>("ContrastRb", 25.f);
 }
 
-void VertexTopology::analyseEvent(const art::Event &, bool) { //print(); }
+void VertexTopology::analyseEvent(const art::Event &, bool) {
+    //print();
+}
 
 void VertexTopology::analyseSlice(const art::Event &event, std::vector<common::ProxyPfpElem_t> &slice_pfp_vec, bool, bool) {
     TVector3 vtx;


### PR DESCRIPTION
## Summary
- Close `analyseEvent` function so subsequent member definitions are valid

## Testing
- `g++ -fsyntax-only AnalysisTools/VertexTopology_tool.cc` *(fails: art/Framework/Principal/Event.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6d3739a4832ea5d23e2f4ba98d4e