### PR TITLE
Add dirt sample to numi FHC workflow

### DIFF
--- a/xml/numi_fhc_workflow.xml
+++ b/xml/numi_fhc_workflow.xml
@@ -11,6 +11,7 @@
     <!ENTITY larsoft_tar "&tar_dir;/strangeness.tar">
 
     <!ENTITY input_def_ext_numi_run1 "nl_prod_mcc9_v08_00_00_45_extnumi_reco2_run1_all_reco2_3000">
+    <!ENTITY input_def_dirt_numi_fhc_run1 "prodgenie_numi_uboone_overlay_dirt_fhc_mcc9_run1_v28_all">
     
     <!ENTITY input_def_strangeness_numi_fhc_run1 "prod_strange_resample_fhc_run2_fhc_reco2_reco2">
     <!ENTITY input_def_strangeness_detvar_cv "detvar_prod_strange_resample_fhc_run1_respin_cv_reco2_reco2">
@@ -67,6 +68,17 @@
     <numjobs>20</numjobs>
 </stage>
 
+
+<stage name="selection_numi_fhc_run1_dirt">
+    <inputdef>&input_def_dirt_numi_fhc_run1;</inputdef>
+    <fcl>&fcl_selection;</fcl>
+    <initsource>&initsrc;</initsource>
+    <outdir>/pnfs/uboone/scratch/users/&user;/ntuples/&release;/&name;/numi_fhc_run1_dirt/out</outdir>
+    <logdir>/pnfs/uboone/scratch/users/&user;/ntuples/&release;/&name;/numi_fhc_run1_dirt/log</logdir>
+    <workdir>/pnfs/uboone/scratch/users/&user;/work/ntuples/&release;/&name;/numi_fhc_run1_dirt</workdir>
+    <datatier>selected</datatier>
+    <numjobs>5000</numjobs>
+</stage>
 
 <stage name="reweight_numi_fhc_run1_beam">
     <inputdef>&input_def_beam_numi_fhc_run1;</inputdef>


### PR DESCRIPTION
## Summary
- include prodgenie_numi_uboone_overlay_dirt FHC Run 1 sample in workflow
- add selection stage for the new dirt dataset
- configure dirt processing to run 5000 jobs

## Testing
- `xmllint --noout xml/numi_fhc_workflow.xml` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.67 8080])* 
- `apt-get install -y libxml2-utils` *(fails: Unable to locate package libxml2-utils)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68bc7c443208832e890139a73622b0a7