### PR TITLE
Fix FHiCL model config syntax

### DIFF
--- a/job/inferencemodels.fcl
+++ b/job/inferencemodels.fcl
@@ -1,4 +1,8 @@
 physics.filters.nuselection.AnalysisTools.image.Models: [
-  { name: "binary", weights_file: "binary_classifier_resnet34.pth", arch: "minkunet" }
+  {
+    name: "binary"
+    weights_file: "binary_classifier_resnet34.pth"
+    arch: "minkunet"
+  }
 ]
 physics.filters.nuselection.AnalysisTools.image.ActiveModels: ["binary"]


### PR DESCRIPTION
## Summary
- correct `inferencemodels.fcl` to use FHiCL table syntax without JSON commas

## Testing
- `./.build.sh` *(fails: mrbsetenv: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0258d627c832eb9c647f7c971b3d3