### PR TITLE
Add ambiguous label for semantic pixel classification

### DIFF
--- a/Imaging/ImageProducer.h
+++ b/Imaging/ImageProducer.h
@@ -104,8 +104,13 @@ inline SemanticPixelClassifier::SemanticLabel ImageProducer::labelSemanticPixels
             if (it_trackid != trackid_to_index.end()) {
                 size_t particle_mcp_idx = it_trackid->second;
                 if (particle_mcp_idx < semantic_label_vector.size()) {
-                    semantic_pixel_label =
-                        semantic_label_vector[particle_mcp_idx];
+                    if (max_ide_fraction <= 0.5f) {
+                        semantic_pixel_label =
+                            SemanticPixelClassifier::SemanticLabel::Ambiguous;
+                    } else {
+                        semantic_pixel_label =
+                            semantic_label_vector[particle_mcp_idx];
+                    }
                 }
             }
         }

--- a/Imaging/SemanticPixelClassifier.h
+++ b/Imaging/SemanticPixelClassifier.h
@@ -63,14 +63,15 @@ class SemanticPixelClassifier {
         Lambda,
         ChargedSigma,
         NeutralSigma,
-        Other
+        Other,
+        Ambiguous
     };
 
-    static inline const std::array<std::string, 15> semantic_label_names = {
-        "Empty", "Cosmic", "Muon", "Electron", "Photon",
-        "ChargedPion", "NeutralPion", "Neutron", "Proton",
-        "ChargedKaon", "NeutralKaon", "Lambda", "ChargedSigma",
-        "NeutralSigma", "Other"};
+    static inline const std::array<std::string, 16> semantic_label_names = {
+        "Empty",    "Cosmic",        "Muon",       "Electron",
+        "Photon",   "ChargedPion",   "NeutralPion", "Neutron",
+        "Proton",   "ChargedKaon",   "NeutralKaon", "Lambda",
+        "ChargedSigma", "NeutralSigma", "Other", "Ambiguous"};
 
     explicit SemanticPixelClassifier(const art::InputTag &MCPproducer)
         : fMCPproducer(MCPproducer) {}


### PR DESCRIPTION
## Summary
- add new `Ambiguous` semantic label and expose in label names
- classify hits as ambiguous when no MC particle contributes more than half of energy

## Testing
- `ctest` *(fails: No test configuration file found)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68c45c532f1c832e84409dd75f7d2e2d