### PR TITLE
Set default ADC threshold to 4

### DIFF
--- a/AnalysisTools/ImageAnalysis_tool.cc
+++ b/AnalysisTools/ImageAnalysis_tool.cc
@@ -221,7 +221,8 @@ void ImageAnalysis::configure(const fhicl::ParameterSet &p) {
 
     _image_width = 512;
     _image_height = 512;
-    _adc_image_threshold = 1.0;
+    // Set the default ADC threshold for image production
+    _adc_image_threshold = 4.0;
     _geo = art::ServiceHandle<geo::Geometry>()->provider();
     _detp = art::ServiceHandle<detinfo::DetectorPropertiesService>()->provider();
     auto clock = art::ServiceHandle<detinfo::DetectorClocksService>()->provider();


### PR DESCRIPTION
## Summary
- Raise default ADC threshold for image production to 4

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c46b896344832e9e362a3d244a2943