### PR TITLE
Remove interaction-vertex fallback for image centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,21 +135,6 @@ With 512\,px images at 3\,mm per pixel, this radius is fixed at
 $R = 76.8\,\text{cm}$ so that all hits within that circle fit inside the
 square image.
 
-If no interaction vertex is available, a robust seed at the
-charge-weighted median of the wire and drift coordinates is used instead.
-Hits are sorted by distance to this seed, and the closest geometry-informed
-fraction of charge is retained before recomputing the centroid.  For a
-512$\times$512 image the half-diagonal is $D_{\text{px}}=\sqrt{256^2+256^2}
-\approx 362\,\text{px}$.  Using a core radius of $R_{\text{px}}=D_{\text{px}}/2
-\approx 180\,\text{px}$ (about $54\,\text{cm}$ at $3\,\text{mm/px}$) gives
-
-$$
-r \simeq \frac{\pi R_{\text{px}}^2}{512^2} \approx \frac{\pi}{8} \approx 0.39,
-$$
-
-meaning the centroid is computed from the nearest $\sim 39\%$ of the total
-charge.
-
 An image of width $W$ and height $H$ with wire and drift pixel sizes $\Delta z$
 and $\Delta x$ spans
 


### PR DESCRIPTION
## Summary
- simplify image centering to rely solely on the reconstructed vertex
- remove robust-seed fallback for events without an interaction vertex
- update README to drop unused centroid seeding description

## Testing
- `make test` (fails: No rule to make target 'test')
- `g++ -std=c++17 -c AnalysisTools/ImageAnalysis_tool.cc -I.` (fails: art/Framework/Principal/Event.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68c497108914832ebe4e603caef03bf4