### PR TITLE
Add inclusive strangeness definition and integrate into TruthAnalysis tool

### DIFF
--- a/AnalysisTools/TruthAnalysis_tool.cc
+++ b/AnalysisTools/TruthAnalysis_tool.cc
@@ -27,6 +27,7 @@
 #include "TTree.h"
 #include "TVector3.h"
 #include <cmath>
+#include <unordered_map>
 #include <limits>
 #include <string>
 #include <vector>
@@ -73,6 +74,17 @@ private:
         float threshold;
         int* counter;
     };
+
+    struct InclusiveStrangenessResult {
+        bool has_inclusive_strangeness = false;
+        int n_phi = 0;
+        bool has_phi_daughter = false;
+        bool has_heavy_feeddown = false;
+    };
+
+    bool HasInclusiveStrangeness(const std::vector<simb::MCParticle>& parts,
+                                 InclusiveStrangenessResult* out = nullptr) const;
+
     std::vector<ParticleCounter> particle_counters;
 
     int _neutrino_pdg;
@@ -191,6 +203,10 @@ private:
     float _true_total_momentum;
     float _true_visible_total_momentum;
     float _true_visible_energy;
+    bool _has_inclusive_strangeness;
+    int _n_phi;
+    bool _has_phi_daughter;
+    bool _has_heavy_feeddown;
 
     void CollectDescendants(const art::ValidHandle<std::vector<simb::MCParticle>>& mcp_h, const std::map<int, art::Ptr<simb::MCParticle>>& mcParticleMap, const art::Ptr<simb::MCParticle>& part, int primary_index);
 };
@@ -361,6 +377,10 @@ void TruthAnalysis::setBranches(TTree* _tree) {
     _tree->Branch("true_total_momentum", &_true_total_momentum, "true_total_momentum/F");
     _tree->Branch("true_visible_total_momentum", &_true_visible_total_momentum, "true_visible_total_momentum/F");
     _tree->Branch("true_visible_energy", &_true_visible_energy, "true_visible_energy/F");
+    _tree->Branch("has_inclusive_strangeness", &_has_inclusive_strangeness, "has_inclusive_strangeness/O");
+    _tree->Branch("n_phi", &_n_phi, "n_phi/I");
+    _tree->Branch("has_phi_daughter", &_has_phi_daughter, "has_phi_daughter/O");
+    _tree->Branch("has_heavy_feeddown", &_has_heavy_feeddown, "has_heavy_feeddown/O");
 }
 
 void TruthAnalysis::resetTTree(TTree* tree) {
@@ -480,6 +500,10 @@ void TruthAnalysis::resetTTree(TTree* tree) {
     _true_total_momentum = 0;
     _true_visible_total_momentum = 0;
     _true_visible_energy = 0;
+    _has_inclusive_strangeness = false;
+    _n_phi = 0;
+    _has_phi_daughter = false;
+    _has_heavy_feeddown = false;
 }
 
 void TruthAnalysis::analyseSlice(const art::Event& event, std::vector<common::ProxyPfpElem_t>& slice_pfp_vec, bool is_data, bool is_selected) {
@@ -559,6 +583,84 @@ void TruthAnalysis::analyseSlice(const art::Event& event, std::vector<common::Pr
             _mc_allchain_completeness[j] = 0.0;
         }
     }
+}
+
+bool TruthAnalysis::HasInclusiveStrangeness(const std::vector<simb::MCParticle>& parts,
+                                            InclusiveStrangenessResult* out) const {
+    const auto is_phi = [](int pdg) { return std::abs(pdg) == 333; };
+    const auto is_kaon = [](int pdg) {
+        int a = std::abs(pdg);
+        return a == 321 || a == 311 || a == 310 || a == 130;
+    };
+    const auto is_s_baryon = [](int pdg) {
+        switch (std::abs(pdg)) {
+            case 3122:
+            case 3112:
+            case 3212:
+            case 3222:
+            case 3312:
+            case 3322:
+            case 3334:
+                return true;
+            default:
+                return false;
+        }
+    };
+    const auto is_charm_hadron = [](int pdg) {
+        int a = std::abs(pdg);
+        return ((400 < a && a < 500 && a != 441 && a != 443 && a != 445) ||
+                (4000 < a && a < 5000));
+    };
+    const auto is_tau = [](int pdg) { return std::abs(pdg) == 15; };
+
+    InclusiveStrangenessResult res;
+    std::unordered_map<int, const simb::MCParticle*> lookup;
+    std::vector<int> fs_ids;
+    for (auto const& p : parts) {
+        lookup[p.TrackId()] = &p;
+        if (!(p.StatusCode() == 1 && p.Process() == "primary")) continue;
+        fs_ids.push_back(p.TrackId());
+        if (is_phi(p.PdgCode())) ++res.n_phi;
+    }
+
+    for (int id : fs_ids) {
+        auto const& h = *lookup[id];
+        int pdg = h.PdgCode();
+        if (!(is_kaon(pdg) || is_s_baryon(pdg))) continue;
+
+        if (is_kaon(pdg)) {
+            auto it = lookup.find(h.Mother());
+            if (it != lookup.end()) {
+                auto const* m = it->second;
+                if (m->StatusCode() == 1 && m->Process() == "primary" && is_phi(m->PdgCode())) {
+                    res.has_phi_daughter = true;
+                    continue;
+                }
+            }
+        }
+
+        const simb::MCParticle* cur = &h;
+        bool drop = false;
+        for (int step = 0; step < 16; ++step) {
+            auto it = lookup.find(cur->Mother());
+            if (it == lookup.end()) break;
+            cur = it->second;
+            int mPdg = cur->PdgCode();
+            if (is_charm_hadron(mPdg) || is_tau(mPdg)) {
+                res.has_heavy_feeddown = true;
+                drop = true;
+                break;
+            }
+            if (cur->StatusCode() == 1 && cur->Process() == "primary") break;
+        }
+        if (drop) continue;
+
+        res.has_inclusive_strangeness = true;
+        break;
+    }
+
+    if (out) *out = res;
+    return res.has_inclusive_strangeness;
 }
 
 void TruthAnalysis::analyseEvent(const art::Event& event, bool is_data) {
@@ -644,7 +746,7 @@ void TruthAnalysis::analyseEvent(const art::Event& event, bool is_data) {
     size_t n_particles = mct.NParticles();
     for (size_t i = 0; i < n_particles; i++) {
         auto const& particle = mct.GetParticle(i);
-        if (particle.StatusCode() != 1) continue;
+        if (!(particle.StatusCode() == 1 && particle.Process() == "primary")) continue;
         total_momentum += particle.Momentum(0);
         total_visible_momentum += particle.Momentum(0);
     }
@@ -655,6 +757,11 @@ void TruthAnalysis::analyseEvent(const art::Event& event, bool is_data) {
     _true_visible_energy = total_visible_momentum.E();
 
     auto const& mcp_h = event.getValidHandle<std::vector<simb::MCParticle>>(fMCPproducer);
+    InclusiveStrangenessResult strangeness;
+    _has_inclusive_strangeness = HasInclusiveStrangeness(*mcp_h, &strangeness);
+    _n_phi = strangeness.n_phi;
+    _has_phi_daughter = strangeness.has_phi_daughter;
+    _has_heavy_feeddown = strangeness.has_heavy_feeddown;
     std::map<int, art::Ptr<simb::MCParticle>> mcParticleMap;
     for (size_t i = 0; i < mcp_h->size(); ++i) {
         mcParticleMap[mcp_h->at(i).TrackId()] = art::Ptr<simb::MCParticle>(mcp_h, i);
@@ -662,7 +769,7 @@ void TruthAnalysis::analyseEvent(const art::Event& event, bool is_data) {
 
     for (int i = 0; i < mct.NParticles(); ++i) {
         const simb::MCParticle& particle = mct.GetParticle(i);
-        if (particle.StatusCode() != 1) continue;
+        if (!(particle.StatusCode() == 1 && particle.Process() == "primary")) continue;
         int pdg = particle.PdgCode();
 
         for (const auto& pc : particle_counters) {

--- a/INCLUSIVE_STRANGENESS.md
+++ b/INCLUSIVE_STRANGENESS.md
@@ -1,0 +1,44 @@
+# Inclusive Strangeness (post-FSI)
+
+An event is counted if the generator final-state list (particles exiting the
+nucleus, pre-detector) contains one or more hadrons with non-zero net
+strangeness (K±, K⁰/K̄⁰, K_S, K_L, Λ/Σ/Ξ/Ω), excluding
+
+1. kaons whose immediate mother is a final-state φ(1020), and
+2. strange hadrons with a charm-hadron or τ ancestor when tracing ancestry
+   up to the nearest final-state ancestor.
+
+This definition is intended to be generator-agnostic and free of switches or
+variants. In LArSoft/GENIE the final-state set corresponds to particles with
+`StatusCode()==1` and `Process()=="primary"`. The TruthAnalysis tool contains a
+compact implementation that mirrors the following pseudocode:
+
+```python
+for h in final_state_particles:
+    if h is not open strangeness: continue
+    if h is kaon and mother is final-state phi: veto
+    walk ancestry to nearest final-state ancestor;
+    if any ancestor is charm hadron or tau: veto
+    return True  # surviving open strangeness
+return False
+```
+
+## PDG Codes
+
+- Kaons: 321, −321, 311, −311, 310 (K_S), 130 (K_L)
+- Strange baryons: 3122, 3112, 3212, 3222, 3312, 3322, 3334
+- φ(1020) (hidden strangeness): 333
+- Heavy-feeddown veto parents: open-charm hadrons (4xx, 4xxx excluding 441/443/445) and τ (15)
+
+The TruthAnalysis tool applies the two vetoes above and returns `true` if at
+least one surviving open-strangeness hadron remains in the final-state set. For
+downstream studies, it also fills an `InclusiveStrangenessResult` structure with
+diagnostics:
+
+- `has_inclusive_strangeness`: event passes the definition above
+- `n_phi`: number of final-state φ(1020)
+- `has_phi_daughter`: at least one kaon removed by the φ-daughter veto
+- `has_heavy_feeddown`: open-strangeness carrier removed due to a charm/τ ancestor
+
+These flags let analyses independently track hidden-strangeness and heavy-flavour
+feed-through channels while still using a common inclusive-strangeness tag.


### PR DESCRIPTION
## Summary
- inline inclusive strangeness evaluation inside `TruthAnalysis` with local helper and diagnostics
- document the definition with minimal pseudocode for generator teams
- refactor PDG helper checks into lambdas inside `HasInclusiveStrangeness` for better encapsulation
- require `Process()=="primary"` when selecting final-state particles

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "install_headers")*

------
https://chatgpt.com/codex/tasks/task_e_68c67f361884832e9685590c68bfafa2