### PR TITLE
Validate associated vertex before dereference in GraphAnalysis::find_slice_primary_vertex

### DIFF
--- a/AnalysisTools/GraphAnalysis_tool.cc
+++ b/AnalysisTools/GraphAnalysis_tool.cc
@@ -529,6 +529,8 @@ bool GraphAnalysis::find_slice_primary_vertex(
         const auto vertices = pfp_proxy.get<recob::Vertex>();
         if (vertices.size() == 0u) continue;
 
+        if (!vertices.at(0)->isValid()) continue;
+
         out.pos = vertices.at(0)->position();
         out.valid = true;
         return true;


### PR DESCRIPTION
### Motivation
- The build failed when a proxy association node was used in a boolean context because association wrapper types do not support `operator!`, so the code must check the underlying associated pointer validity before dereferencing.

### Description
- Add an explicit validity guard `if (!vertices.at(0)->isValid()) continue;` in `GraphAnalysis::find_slice_primary_vertex` to skip invalid associated `recob::Vertex` entries before calling `position()`.

### Testing
- No automated build or unit tests were run in this container because the LArSoft build environment is not available here; basic repository checks (`git diff`, `git status`, commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c967fce4e0832eb9b05cebc09f8649)